### PR TITLE
fix: error call to a member function `find()` on null when run seeder

### DIFF
--- a/app/Concerns/ImpactsForumCounts.php
+++ b/app/Concerns/ImpactsForumCounts.php
@@ -4,6 +4,7 @@ namespace App\Concerns;
 
 use App\Entities\Forum;
 use App\Models\ForumModel;
+use App\Models\ThreadModel;
 
 trait ImpactsForumCounts
 {


### PR DESCRIPTION
```console
P:\ci4\appstarter>php spark db:seed SampleDataSeeder

CodeIgniter v4.4.0 Command Line Tool - Server Time: 2023-08-26 20:14:42 UTC+00:00


[Error]

Call to a member function find() on null

at APPPATH\Concerns\ImpactsForumCounts.php:66
```