### PR TITLE
Installation fixes

### DIFF
--- a/_docs/start.md
+++ b/_docs/start.md
@@ -23,7 +23,7 @@ Once the reposoitory has been installed on your local machine you need to get a 
 ```cli
 composer install  (only needed if you directly downloaded the files)
 npm install
-php spark migrate
+php spark migrate --all
 php spark db:seed SampleDataSeeder  (only if you want sample forums, users, etc created)
 ```
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "649f615cbeb539567be09cb340913ae2",
+    "content-hash": "d1267b7b514955ea751494b808b4f648",
     "packages": [
         {
             "name": "codeigniter4/framework",
@@ -535,16 +535,16 @@
         },
         {
             "name": "michalsn/codeigniter-htmx",
-            "version": "v1.2.1",
+            "version": "v1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/michalsn/codeigniter-htmx.git",
-                "reference": "a85c93ac9ed288ef2b13ad7a4b905ac134d4a0cd"
+                "reference": "1d320175ebd89df324813b99974dada44f72e428"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/michalsn/codeigniter-htmx/zipball/a85c93ac9ed288ef2b13ad7a4b905ac134d4a0cd",
-                "reference": "a85c93ac9ed288ef2b13ad7a4b905ac134d4a0cd",
+                "url": "https://api.github.com/repos/michalsn/codeigniter-htmx/zipball/1d320175ebd89df324813b99974dada44f72e428",
+                "reference": "1d320175ebd89df324813b99974dada44f72e428",
                 "shasum": ""
             },
             "require": {
@@ -553,7 +553,7 @@
             "require-dev": {
                 "codeigniter4/devkit": "^1.0",
                 "codeigniter4/framework": "^4.1",
-                "rector/rector": "0.17.1"
+                "rector/rector": "0.18.0"
             },
             "type": "library",
             "autoload": {
@@ -584,9 +584,9 @@
             ],
             "support": {
                 "issues": "https://github.com/michalsn/codeigniter-htmx/issues",
-                "source": "https://github.com/michalsn/codeigniter-htmx/tree/v1.2.1"
+                "source": "https://github.com/michalsn/codeigniter-htmx/tree/v1.2.2"
             },
-            "time": "2023-06-17T09:50:49+00:00"
+            "time": "2023-08-26T06:16:31+00:00"
         },
         {
             "name": "nette/schema",

--- a/writable/.htaccess
+++ b/writable/.htaccess
@@ -1,0 +1,6 @@
+<IfModule authz_core_module>
+    Require all denied
+</IfModule>
+<IfModule !authz_core_module>
+    Deny from all
+</IfModule>

--- a/writable/cache/index.html
+++ b/writable/cache/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>403 Forbidden</title>
+</head>
+<body>
+
+<p>Directory access is forbidden.</p>
+
+</body>
+</html>

--- a/writable/logs/index.html
+++ b/writable/logs/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>403 Forbidden</title>
+</head>
+<body>
+
+<p>Directory access is forbidden.</p>
+
+</body>
+</html>

--- a/writable/session/index.html
+++ b/writable/session/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>403 Forbidden</title>
+</head>
+<body>
+
+<p>Directory access is forbidden.</p>
+
+</body>
+</html>

--- a/writable/uploads/index.html
+++ b/writable/uploads/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>403 Forbidden</title>
+</head>
+<body>
+
+<p>Directory access is forbidden.</p>
+
+</body>
+</html>


### PR DESCRIPTION
I came across some issues during the installation process. This PR is about to fix them.

* update composer.lock - otherwise the `composer install` command returns a message
> - Required package "michalsn/codeigniter-htmx" is in the lock file as "v1.2.1" but that does not satisfy your constraint "^1.2.2".

* add `writable` folder to the repo, to fix fatal error
> Fatal error: Uncaught CodeIgniter\Cache\Exceptions\CacheException: Cache unable to write to "/cache/". in /Users/michalsn/Sites/forum/vendor/codeigniter4/framework/system/Cache/Handlers/FileHandler.php:64

* update spark command from `php spark migrate` to `php spark migrate --all` which will also run Shield migrations