### PR TITLE
fix: Reduce the number of produced queries

### DIFF
--- a/app/Entities/Thread.php
+++ b/app/Entities/Thread.php
@@ -27,8 +27,10 @@ class Thread extends Entity
      */
     public function link()
     {
-        $forum = model(ForumModel::class)->find($this->forum_id);
+        $forum_slug = isset($this->forum_slug) ?
+            $this->forum_slug :
+            model(ForumModel::class)->find($this->forum_id)?->slug;
 
-        return route_to('thread', $forum->slug, $this->slug);
+        return route_to('thread', $forum_slug, $this->slug);
     }
 }

--- a/app/Models/ThreadModel.php
+++ b/app/Models/ThreadModel.php
@@ -61,6 +61,7 @@ class ThreadModel extends Model
         $selects = [
             'threads.*',
             'forums.title as forum_title',
+            'forums.slug as forum_slug',
             'posts.created_at as last_post_created_at',
             'users.username as last_post_author',
         ];


### PR DESCRIPTION
This PR reduces the number of executed queries in the Discussions tab.

Now, we're dealing with n+1 problem. Luckily it was easily fixable.