### PR TITLE
chore: add `xsl` to require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "require": {
     "php": "^7.4 || ^8.0",
+    "ext-xsl" : "*",
     "codeigniter4/framework": "^4.4",
     "codeigniter4/shield": "^1.0@beta",
     "league/commonmark": "^2.3",


### PR DESCRIPTION
We needed `XSLTProcessor::class` so `xsl` is require.