### PR TITLE
enable the csrf filter

### DIFF
--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -36,7 +36,7 @@ class Filters extends BaseConfig
     public array $globals = [
         'before' => [
             // 'honeypot',
-            // 'csrf',
+            'csrf',
             // 'invalidchars',
         ],
         'after' => [


### PR DESCRIPTION
We use `form_open()` so I enabled `csrf` filter by default.

superseded #37
close #37 