### PR TITLE
code cleanup

### DIFF
--- a/app/Common.php
+++ b/app/Common.php
@@ -13,17 +13,13 @@
  *
  * @see: https://codeigniter4.github.io/CodeIgniter4/
  */
-
 if (! function_exists('policy')) {
     /**
      * A convenience method for accessing the Policy service.
      *
-     * @param string $permission
-     * @param mixed  $arguments
-     *
      * @return mixed
      */
-    function policy(string $permission, ...$arguments)
+    function policy(string $permission, mixed ...$arguments)
     {
         return service('policy')->check($permission, ...$arguments);
     }

--- a/app/Config/Services.php
+++ b/app/Config/Services.php
@@ -2,6 +2,7 @@
 
 namespace Config;
 
+use App\Libraries\Policies\Policy;
 use CodeIgniter\Config\BaseService;
 
 /**
@@ -25,6 +26,6 @@ class Services extends BaseService
             return static::getSharedInstance('policy');
         }
 
-        return new \App\Libraries\Policies\Policy();
+        return new Policy();
     }
 }

--- a/app/Controllers/ErrorController.php
+++ b/app/Controllers/ErrorController.php
@@ -2,8 +2,6 @@
 
 namespace App\Controllers;
 
-use App\Controllers\BaseController;
-
 class ErrorController extends BaseController
 {
     /**
@@ -24,7 +22,7 @@ class ErrorController extends BaseController
             : 'errors/html/error.php';
 
         return view($view, [
-            'status' => session('status'),
+            'status'  => session('status'),
             'message' => session('message'),
         ]);
     }

--- a/app/Libraries/Policies/Policy.php
+++ b/app/Libraries/Policies/Policy.php
@@ -1,10 +1,10 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Libraries\Policies;
 
 use App\Entities\User;
-use InvalidArgumentException;
-use RuntimeException;
 
 /**
  * Provides centralized autnorization based around policies
@@ -37,7 +37,7 @@ class Policy
 
         // If the method doesn't exist, then we'll just check
         // against the user's permissions.
-        if (!$policy || !method_exists($policy, $method)) {
+        if (! $policy || ! method_exists($policy, $method)) {
             return $user->can($permission);
         }
 
@@ -51,7 +51,7 @@ class Policy
         }
 
         // Call the policy method and return the result.
-        return $policy->$method($user, ...$args);
+        return $policy->{$method}($user, ...$args);
     }
 
     /**
@@ -70,7 +70,7 @@ class Policy
      */
     public function withPolicy(PolicyInterface $policy): self
     {
-        $this->policies[get_class($policy)] = $policy;
+        $this->policies[$policy::class] = $policy;
 
         return $this;
     }

--- a/app/Libraries/Policies/PolicyInterface.php
+++ b/app/Libraries/Policies/PolicyInterface.php
@@ -4,5 +4,4 @@ namespace App\Libraries\Policies;
 
 interface PolicyInterface
 {
-
 }

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
   "require-dev": {
     "codeigniter4/devkit": "^1.1",
     "mockery/mockery": "^1.6",
+    "phpstan/phpstan-mockery": "^1.1",
     "rector/rector": "0.18.3"
   },
   "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ef73f690a80ce9b98198dd860bdbb0b9",
+    "content-hash": "91f0cb2a6637ff046bb880838929ecdd",
     "packages": [
         {
             "name": "codeigniter4/framework",
@@ -3094,6 +3094,56 @@
                 "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/1.1.4"
             },
             "time": "2023-08-05T09:02:04+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-mockery",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-mockery.git",
+                "reference": "6aa86bd8e9c9a1be97baf0558d4a2ed1374736a6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-mockery/zipball/6aa86bd8e9c9a1be97baf0558d4a2ed1374736a6",
+                "reference": "6aa86bd8e9c9a1be97baf0558d4a2ed1374736a6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.10"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.2.4",
+                "nikic/php-parser": "^4.13.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan Mockery extension",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-mockery/issues",
+                "source": "https://github.com/phpstan/phpstan-mockery/tree/1.1.1"
+            },
+            "time": "2023-02-18T13:54:03+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,6 +13,7 @@ parameters:
 		- app/Views/*
 		- app/Libraries/TextFormatter.php
 	ignoreErrors:
+	    - '#Call to deprecated method getStatusCode\(\) of class CodeIgniter\\HTTP\\Response:#'
 	    - '#Call to an undefined method CodeIgniter\\Database\\ConnectionInterface::[A-Za-z].+\(\)#'
 	    - '#Cannot access property [\$a-z_]+ on (array|object)#'
 	    - '#Cannot call method [fill\|\|link\|\|hasChanged].+\(\) on array\|object.#'
@@ -22,6 +23,7 @@ parameters:
 	    	message: '#Call to deprecated function random_string\(\):#'
 	    	paths:
 	    	    - app/Models/Factories/UserFactory.php
+	treatPhpDocTypesAsCertain: false
 	universalObjectCratesClasses:
 		- CodeIgniter\Entity
 		- CodeIgniter\Entity\Entity

--- a/tests/Policies/PolicyTest.php
+++ b/tests/Policies/PolicyTest.php
@@ -1,11 +1,13 @@
 <?php
 
+use App\Entities\User;
 use App\Libraries\Policies\Policy;
 use App\Models\UserModel;
+use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use Mockery as m;
 use Tests\Support\Policies\TestPolicy;
-use \Mockery as m;
 
 /**
  * @internal
@@ -26,6 +28,7 @@ final class PolicyTest extends CIUnitTestCase
     public function testCanOnlyUserPermissions()
     {
         $policy = new Policy();
+        /** @var User $user */
         $user = fake(UserModel::class);
         $user->addGroup('user');
 
@@ -41,6 +44,7 @@ final class PolicyTest extends CIUnitTestCase
 
     public function testCanSuccess()
     {
+        /** @var User $user */
         $user = fake(UserModel::class);
         $user->addGroup('user');
 
@@ -58,6 +62,7 @@ final class PolicyTest extends CIUnitTestCase
 
     public function testCanWithArguments()
     {
+        /** @var User $user */
         $user = fake(UserModel::class);
         $user->addGroup('user');
         $otherUser = fake(UserModel::class);
@@ -102,11 +107,11 @@ final class PolicyTest extends CIUnitTestCase
 
         $response = $policy->deny('You are not allowed to create threads.');
 
-        $this->assertInstanceOf(\CodeIgniter\HTTP\RedirectResponse::class, $response);
-        $this->assertEquals(200, $response->getStatusCode()); // Set by codeigniter-htmx
-        $this->assertEquals(403, session()->getFlashdata('status'));
-        $this->assertEquals('You are not allowed to create threads.', session()->getFlashdata('error'));
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame(200, $response->getStatusCode()); // Set by codeigniter-htmx
+        $this->assertSame(403, session()->getFlashdata('status'));
+        $this->assertSame('You are not allowed to create threads.', session()->getFlashdata('error'));
         // Should have set the HX-Location header
-        $this->assertEquals(json_encode(['path' => route_to('general-error')]), $response->getHeaderLine('HX-Location'));
+        $this->assertSame(json_encode(['path' => route_to('general-error')]), $response->getHeaderLine('HX-Location'));
     }
 }

--- a/tests/_support/Policies/TestPolicy.php
+++ b/tests/_support/Policies/TestPolicy.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Tests\Support\Policies;
 
@@ -29,8 +31,8 @@ class TestPolicy implements PolicyInterface
      */
     public function edit(User $user, User $targetUser): bool
     {
-        return $user->inGroup('admin') &&
-            ! $targetUser->inGroup('superadmin');
+        return $user->inGroup('admin')
+            && ! $targetUser->inGroup('superadmin');
     }
 
     /**
@@ -38,7 +40,7 @@ class TestPolicy implements PolicyInterface
      */
     public function delete(User $user, User $targetUser): bool
     {
-        return $user->inGroup('superadmin') &&
-            ! $targetUser->inGroup('superadmin');
+        return $user->inGroup('superadmin')
+            && ! $targetUser->inGroup('superadmin');
     }
 }


### PR DESCRIPTION
This PR makes a code cleanup for Policies.

The `phpstan/phpstan-mockery` package is added to make PHPStan happy when working with Mockery.

Not sure how long we gonna stick to all these checks, but I have to admit (besides these silly complaints about types) that it makes code cleaner.