### PR TITLE
feat: image upload

### DIFF
--- a/_docs/images.md
+++ b/_docs/images.md
@@ -1,0 +1,27 @@
+# Images
+
+## Overview
+
+Images are available for threads and posts. We can attach them by drag and drop or by pasting from the clipboard.
+
+Main rules:
+
+- Every uploaded image is publicly visible.
+- We can upload PNG and JPEG files up to 2MB in size.
+- Files are stored in: `public/uploads/{userId}/{randomFileName}.{ext}`.
+- We track whether each uploaded file is actually used in the message body to prevent abuse.
+- We should set up `.htaccess` file with proper rules to block hotlinking.
+
+## Database
+
+The design of the `images` table makes it easy to delete files from disk when we introduce the option to permanently delete threads/posts in the future.
+
+## Cron
+
+We need to set up a cron job to delete orphaned files. Such a task should be executed once an hour.
+
+```cli
+0 * * * * php spark cleanup:images 3
+```
+
+The above task will delete files that have not been assigned to any thread/post for three hours.

--- a/app/Commands/CleanupImages.php
+++ b/app/Commands/CleanupImages.php
@@ -61,11 +61,18 @@ class CleanupImages extends BaseCommand
     public function run(array $params)
     {
         $hours = array_shift($params) ?? 3;
+        $date  = Time::now()->subHours($hours)->format('Y-m-d H:i:s');
 
         $db    = db_connect();
         $query = $db->table('images')
             ->where('is_used', 0)
-            ->where('created_at <', Time::now()->subHours($hours)->format('Y-m-d H:i:s'))
+            ->groupStart()
+            ->groupStart()
+            ->where('thread_id', null)
+            ->where('created_at <', $date)
+            ->groupEnd()
+            ->orWhere('thread_id !=', null)
+            ->groupEnd()
             ->get();
 
         $delete = [];

--- a/app/Commands/CleanupImages.php
+++ b/app/Commands/CleanupImages.php
@@ -43,7 +43,7 @@ class CleanupImages extends BaseCommand
      * @var array
      */
     protected $arguments = [
-        'hours' => 'After how many hours image is treated as expired.'
+        'hours' => 'After how many hours image is treated as expired.',
     ];
 
     /**
@@ -55,8 +55,6 @@ class CleanupImages extends BaseCommand
 
     /**
      * Actually execute a command.
-     *
-     * @param array $params
      *
      * @throws Exception
      */

--- a/app/Commands/CleanupImages.php
+++ b/app/Commands/CleanupImages.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Commands;
+
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\CLI;
+use CodeIgniter\I18n\Time;
+use Exception;
+
+class CleanupImages extends BaseCommand
+{
+    /**
+     * The Command's Group
+     *
+     * @var string
+     */
+    protected $group = 'Forum';
+
+    /**
+     * The Command's Name
+     *
+     * @var string
+     */
+    protected $name = 'cleanup:images';
+
+    /**
+     * The Command's Description
+     *
+     * @var string
+     */
+    protected $description = 'Delete images that are no longer used.';
+
+    /**
+     * The Command's Usage
+     *
+     * @var string
+     */
+    protected $usage = 'cleanup:images <hours>';
+
+    /**
+     * The Command's Arguments
+     *
+     * @var array
+     */
+    protected $arguments = [
+        'hours' => 'After how many hours image is treated as expired.'
+    ];
+
+    /**
+     * The Command's Options
+     *
+     * @var array
+     */
+    protected $options = [];
+
+    /**
+     * Actually execute a command.
+     *
+     * @param array $params
+     *
+     * @throws Exception
+     */
+    public function run(array $params)
+    {
+        $hours = array_shift($params) ?? 3;
+
+        $db    = db_connect();
+        $query = $db->table('images')
+            ->where('is_used', 0)
+            ->where('created_at <', Time::now()->subHours($hours)->format('Y-m-d H:i:s'))
+            ->get();
+
+        $delete = [];
+
+        // Get images that are no longer used
+        while ($row = $query->getUnbufferedRow()) {
+            $path = ['uploads', $row->user_id, $row->name];
+            // Delete image from disc
+            unlink(FCPATH . implode(DIRECTORY_SEPARATOR, $path));
+            // Save ID for later
+            $delete[] = $row->id;
+        }
+
+        // Delete images from DB
+        if (! empty($delete)) {
+            $db->table('images')->whereIn('id', $delete)->delete();
+        }
+
+        CLI::write('Image cleanup finished.', 'green');
+        CLI::write('Deleted images: ' . count($delete), 'light_yellow');
+    }
+}

--- a/app/Concerns/HasImages.php
+++ b/app/Concerns/HasImages.php
@@ -19,11 +19,7 @@ trait HasImages
             return $eventData;
         }
 
-        if (is_array($eventData['id'])) {
-            $threadId = (int) $eventData['id'][0];
-        } else {
-            $threadId = (int) $eventData['id'];
-        }
+        $threadId = is_array($eventData['id']) ? (int) $eventData['id'][0] : (int) $eventData['id'];
 
         $imageModel = model(ImageModel::class);
 
@@ -34,7 +30,7 @@ trait HasImages
         }
 
         foreach ($images as $image) {
-            if (str_contains($eventData['data']['body'], $image->name)) {
+            if (str_contains((string) $eventData['data']['body'], (string) $image->name)) {
                 $image->thread_id = $threadId;
                 $image->is_used   = true;
             } else {
@@ -59,11 +55,7 @@ trait HasImages
             return $eventData;
         }
 
-        if (is_array($eventData['id'])) {
-            $postId = (int) $eventData['id'][0];
-        } else {
-            $postId = (int) $eventData['id'];
-        }
+        $postId = is_array($eventData['id']) ? (int) $eventData['id'][0] : (int) $eventData['id'];
 
         $imageModel = model(ImageModel::class);
 
@@ -74,7 +66,7 @@ trait HasImages
         }
 
         foreach ($images as $image) {
-            if (str_contains($eventData['data']['body'], $image->name)) {
+            if (str_contains((string) $eventData['data']['body'], (string) $image->name)) {
                 $image->thread_id = (int) $eventData['data']['thread_id'];
                 $image->post_id   = $postId;
                 $image->is_used   = true;

--- a/app/Concerns/HasImages.php
+++ b/app/Concerns/HasImages.php
@@ -22,15 +22,15 @@ trait HasImages
         $threadId = is_array($eventData['id']) ? (int) $eventData['id'][0] : (int) $eventData['id'];
 
         $imageModel = model(ImageModel::class);
-
-        $images = $imageModel->findForCheck($eventData['data']['author_id'], $threadId);
+        $images     = $imageModel->findForCheck($eventData['data']['author_id'], $threadId);
 
         if (! $images) {
             return $eventData;
         }
 
         foreach ($images as $image) {
-            if (str_contains((string) $eventData['data']['body'], (string) $image->name)) {
+            $fileUrl = base_url(implode('/', ['uploads', $eventData['data']['author_id'], $image->name]));
+            if (str_contains((string) $eventData['data']['body'], $fileUrl)) {
                 $image->thread_id = $threadId;
                 $image->is_used   = true;
             } else {
@@ -58,15 +58,15 @@ trait HasImages
         $postId = is_array($eventData['id']) ? (int) $eventData['id'][0] : (int) $eventData['id'];
 
         $imageModel = model(ImageModel::class);
-
-        $images = $imageModel->findForCheck($eventData['data']['author_id'], $eventData['data']['thread_id'], $postId);
+        $images     = $imageModel->findForCheck($eventData['data']['author_id'], $eventData['data']['thread_id'], $postId);
 
         if (! $images) {
             return $eventData;
         }
 
         foreach ($images as $image) {
-            if (str_contains((string) $eventData['data']['body'], (string) $image->name)) {
+            $fileUrl = base_url(implode('/', ['uploads', $eventData['data']['author_id'], $image->name]));
+            if (str_contains((string) $eventData['data']['body'], $fileUrl)) {
                 $image->thread_id = (int) $eventData['data']['thread_id'];
                 $image->post_id   = $postId;
                 $image->is_used   = true;

--- a/app/Concerns/HasImages.php
+++ b/app/Concerns/HasImages.php
@@ -12,9 +12,9 @@ trait HasImages
      */
     protected function updateThreadImages(array $eventData): array
     {
-        if (! $eventData['result'] ||
-            (is_array($eventData['id']) && count($eventData['id']) > 1) ||
-            ! isset($eventData['data']['author_id'])
+        if (! $eventData['result']
+            || (is_array($eventData['id']) && count($eventData['id']) > 1)
+            || ! isset($eventData['data']['author_id'])
         ) {
             return $eventData;
         }
@@ -52,9 +52,9 @@ trait HasImages
      */
     protected function updatePostImages(array $eventData): array
     {
-        if (! $eventData['result'] ||
-            (is_array($eventData['id']) && count($eventData['id']) > 1) ||
-            ! isset($eventData['data']['author_id'])
+        if (! $eventData['result']
+            || (is_array($eventData['id']) && count($eventData['id']) > 1)
+            || ! isset($eventData['data']['author_id'])
         ) {
             return $eventData;
         }

--- a/app/Concerns/HasImages.php
+++ b/app/Concerns/HasImages.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Concerns;
+
+use App\Models\ImageModel;
+use ReflectionException;
+
+trait HasImages
+{
+    /**
+     * @throws ReflectionException
+     */
+    protected function updateThreadImages(array $eventData): array
+    {
+        if (! $eventData['result'] ||
+            (is_array($eventData['id']) && count($eventData['id']) > 1) ||
+            ! isset($eventData['data']['author_id'])
+        ) {
+            return $eventData;
+        }
+
+        if (is_array($eventData['id'])) {
+            $threadId = (int) $eventData['id'][0];
+        } else {
+            $threadId = (int) $eventData['id'];
+        }
+
+        $imageModel = model(ImageModel::class);
+
+        $images = $imageModel->findForCheck($eventData['data']['author_id'], $threadId);
+
+        if (! $images) {
+            return $eventData;
+        }
+
+        foreach ($images as $image) {
+            if (str_contains($eventData['data']['body'], $image->name)) {
+                $image->thread_id = $threadId;
+                $image->is_used   = true;
+            } else {
+                $image->is_used = false;
+            }
+        }
+
+        $imageModel->updateBatch($images, 'id');
+
+        return $eventData;
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    protected function updatePostImages(array $eventData): array
+    {
+        if (! $eventData['result'] ||
+            (is_array($eventData['id']) && count($eventData['id']) > 1) ||
+            ! isset($eventData['data']['author_id'])
+        ) {
+            return $eventData;
+        }
+
+        if (is_array($eventData['id'])) {
+            $postId = (int) $eventData['id'][0];
+        } else {
+            $postId = (int) $eventData['id'];
+        }
+
+        $imageModel = model(ImageModel::class);
+
+        $images = $imageModel->findForCheck($eventData['data']['author_id'], $eventData['data']['thread_id'], $postId);
+
+        if (! $images) {
+            return $eventData;
+        }
+
+        foreach ($images as $image) {
+            if (str_contains($eventData['data']['body'], $image->name)) {
+                $image->thread_id = (int) $eventData['data']['thread_id'];
+                $image->post_id   = $postId;
+                $image->is_used   = true;
+            } else {
+                $image->is_used = false;
+            }
+        }
+
+        $imageModel->updateBatch($images, 'id');
+
+        return $eventData;
+    }
+}

--- a/app/Concerns/HasTags.php
+++ b/app/Concerns/HasTags.php
@@ -33,7 +33,7 @@ trait HasTags
      */
     public function addTags(array $tags): static
     {
-        $this->tags = array_unique(array_merge($this->tags, $tags));
+        $this->tags = array_filter(array_unique(array_merge($this->tags, $tags)));
 
         $this->withTags();
 
@@ -45,7 +45,7 @@ trait HasTags
      */
     public function removeTags(array $tags): static
     {
-        $this->tags = array_diff($this->tags, $tags);
+        $this->tags = array_filter(array_diff($this->tags, $tags));
 
         $this->withTags();
 
@@ -57,7 +57,7 @@ trait HasTags
      */
     public function replaceTags(array $tags): static
     {
-        $this->tags = array_unique($tags);
+        $this->tags = array_filter(array_unique($tags));
 
         $this->withTags();
 

--- a/app/Config/AuthGroups.php
+++ b/app/Config/AuthGroups.php
@@ -77,6 +77,7 @@ class AuthGroups extends ShieldAuthGroups
         'posts.delete'        => 'Can delete posts',
         'posts.create'        => 'Can create posts',
         'posts.moderate'      => 'Can moderate posts',
+        'images.upload'       => 'Can upload images',
     ];
 
     /**
@@ -92,6 +93,7 @@ class AuthGroups extends ShieldAuthGroups
             'beta.*',
             'categories.*',
             'posts.*',
+            'images.*'
         ],
         'admin' => [
             'admin.access',
@@ -101,6 +103,7 @@ class AuthGroups extends ShieldAuthGroups
             'beta.access',
             'categories.*',
             'posts.*',
+            'images.*'
         ],
         'developer' => [
             'admin.access',
@@ -108,10 +111,12 @@ class AuthGroups extends ShieldAuthGroups
             'users.create',
             'users.edit',
             'beta.access',
+            'images.upload',
         ],
         'user' => [
             'threads.create',
             'posts.create',
+            'images.upload',
         ],
         'beta' => [
             'beta.access',

--- a/app/Config/AuthGroups.php
+++ b/app/Config/AuthGroups.php
@@ -93,7 +93,7 @@ class AuthGroups extends ShieldAuthGroups
             'beta.*',
             'categories.*',
             'posts.*',
-            'images.*'
+            'images.*',
         ],
         'admin' => [
             'admin.access',
@@ -103,7 +103,7 @@ class AuthGroups extends ShieldAuthGroups
             'beta.access',
             'categories.*',
             'posts.*',
-            'images.*'
+            'images.*',
         ],
         'developer' => [
             'admin.access',

--- a/app/Controllers/Discussions/ImageController.php
+++ b/app/Controllers/Discussions/ImageController.php
@@ -63,9 +63,10 @@ class ImageController extends BaseController
 
         // Save file name to the DB
         if (! model(ImageModel::class)->insert([
-            'user_id' => user_id(),
-            'name'    => $newName,
-            'size'    => $file->getSize(),
+            'user_id'    => user_id(),
+            'name'       => $newName,
+            'size'       => $file->getSize(),
+            'ip_address' => $this->request->getIPAddress(),
         ])) {
             unlink($newPath . DIRECTORY_SEPARATOR . $newName);
 

--- a/app/Controllers/Discussions/ImageController.php
+++ b/app/Controllers/Discussions/ImageController.php
@@ -27,7 +27,7 @@ class ImageController extends BaseController
         if (! $this->validate([
             'image' => [
                 'uploaded[image]', 'max_size[image,2048]',
-                'mime_in[image,image/png,image/jpeg]', 'ext_in[image,png,jpg,jpeg]'
+                'mime_in[image,image/png,image/jpeg]', 'ext_in[image,png,jpg,jpeg]',
             ],
         ])) {
             return $this->response->setStatusCode(400)->setJSON([
@@ -68,6 +68,7 @@ class ImageController extends BaseController
             'size'    => $file->getSize(),
         ])) {
             unlink($newPath . DIRECTORY_SEPARATOR . $newName);
+
             return $this->response->setStatusCode(400)->setJSON([
                 'error' => 'Saving file to the DB failed.',
             ]);

--- a/app/Controllers/Discussions/ImageController.php
+++ b/app/Controllers/Discussions/ImageController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Controllers\Discussions;
+
+use App\Controllers\BaseController;
+use App\Models\ImageModel;
+use ReflectionException;
+
+/**
+ * Class Image
+ */
+class ImageController extends BaseController
+{
+    /**
+     * Upload image and return uploaded file URL.
+     *
+     * @throws ReflectionException
+     */
+    public function upload()
+    {
+        if (! $this->policy->can('images.upload')) {
+            return $this->response->setStatusCode(401)->setJSON([
+                'error' => 'You are not allowed to upload images.',
+            ]);
+        }
+
+        if (! $this->validate([
+            'image' => [
+                'uploaded[image]', 'max_size[image,2048]',
+                'mime_in[image,image/png,image/jpeg]', 'ext_in[image,png,jpg,jpeg]'
+            ],
+        ])) {
+            return $this->response->setStatusCode(400)->setJSON([
+                'error' => implode(PHP_EOL, $this->validator->getErrors()),
+            ]);
+        }
+
+        $file = $this->request->getFile('image');
+
+        // Check if image was successfully uploaded
+        if (! $file->isValid()) {
+            return $this->response->setStatusCode(400)->setJSON([
+                'error' => $file->getErrorString() . '(' . $file->getError() . ')',
+            ]);
+        }
+
+        $newName = $file->getRandomName();
+        $newPath = implode(DIRECTORY_SEPARATOR, ['uploads', user_id()]);
+
+        // Create directory if needed
+        if (! is_dir($newPath) && ! mkdir($newPath, 0755, true)) {
+            return $this->response->setStatusCode(400)->setJSON([
+                'error' => 'Creating directory failed.',
+            ]);
+        }
+
+        // Check if image was successfully moved
+        if (! $file->move(FCPATH . $newPath, $newName)) {
+            return $this->response->setStatusCode(400)->setJSON([
+                'error' => 'Check your permissions to the final destination folder.',
+            ]);
+        }
+
+        // Save file name to the DB
+        if (! model(ImageModel::class)->insert([
+            'user_id' => user_id(),
+            'name'    => $newName,
+            'size'    => $file->getSize(),
+        ])) {
+            unlink($newPath . DIRECTORY_SEPARATOR . $newName);
+            return $this->response->setStatusCode(400)->setJSON([
+                'error' => 'Saving file to the DB failed.',
+            ]);
+        }
+
+        return $this->response->setJSON([
+            'data' => ['filePath' => $newPath . DIRECTORY_SEPARATOR . $newName],
+        ]);
+    }
+}

--- a/app/Database/Migrations/2023-09-22-191657_CreateImageTable.php
+++ b/app/Database/Migrations/2023-09-22-191657_CreateImageTable.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class CreateImageTable extends Migration
+{
+    public function up()
+    {
+        $this->forge->addField([
+            'id'         => ['type' => 'int', 'constraint' => 11, 'unsigned' => true, 'auto_increment' => true],
+            'user_id'    => ['type' => 'int', 'constraint' => 11, 'unsigned' => true],
+            'thread_id'  => ['type' => 'int', 'constraint' => 11, 'unsigned' => true, 'null' => true],
+            'post_id'    => ['type' => 'int', 'constraint' => 11, 'unsigned' => true, 'null' => true],
+            'name'       => ['type' => 'varchar', 'constraint' => 255, 'null' => false],
+            'size'       => ['type' => 'int', 'constraint' => 11, 'unsigned' => true, 'null' => false],
+            'is_used'    => ['type' => 'tinyint', 'constraint' => 2, 'default' => 0],
+            'ip_address' => ['type' => 'varchar', 'constraint' => 45, 'null' => true],
+            'created_at' => ['type' => 'datetime', 'null' => false],
+            'updated_at' => ['type' => 'datetime', 'null' => false],
+        ]);
+        $this->forge->addPrimaryKey('id');
+        $this->forge->addForeignKey('user_id', 'users', 'id', '', 'delete');
+        $this->forge->addForeignKey('thread_id', 'threads', 'id', '', 'delete');
+        $this->forge->addForeignKey('post_id', 'posts', 'id', '', 'delete');
+        $this->forge->createTable('images', true);
+    }
+
+    public function down()
+    {
+        $this->forge->dropTable('images', true);
+    }
+}

--- a/app/Entities/Image.php
+++ b/app/Entities/Image.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Entities;
+
+use CodeIgniter\Entity\Entity;
+
+class Image extends Entity
+{
+    protected $datamap = [];
+    protected $dates   = ['created_at', 'updated_at'];
+    protected $casts   = [
+        'id' => 'integer',
+        'user_id' => 'integer',
+        'thread_id' => '?integer',
+        'post_id' => '?integer',
+        'size' => 'integer',
+        'is_used' => 'bool',
+    ];
+}

--- a/app/Entities/Image.php
+++ b/app/Entities/Image.php
@@ -9,11 +9,11 @@ class Image extends Entity
     protected $datamap = [];
     protected $dates   = ['created_at', 'updated_at'];
     protected $casts   = [
-        'id' => 'integer',
-        'user_id' => 'integer',
+        'id'        => 'integer',
+        'user_id'   => 'integer',
         'thread_id' => '?integer',
-        'post_id' => '?integer',
-        'size' => 'integer',
-        'is_used' => 'bool',
+        'post_id'   => '?integer',
+        'size'      => 'integer',
+        'is_used'   => 'bool',
     ];
 }

--- a/app/Models/Factories/ImageFactory.php
+++ b/app/Models/Factories/ImageFactory.php
@@ -18,7 +18,7 @@ class ImageFactory extends ImageModel
             'thread_id'  => null,
             'post_id'    => null,
             'name'       => $faker->regexify('[0-9]{10}_[a-z0-9]{20}') . '.jpg',
-            'size'       => rand(100000, 2000000),
+            'size'       => random_int(100000, 2_000_000),
             'is_used'    => 0,
             'ip_address' => $faker->ipv4,
         ]);

--- a/app/Models/Factories/ImageFactory.php
+++ b/app/Models/Factories/ImageFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models\Factories;
+
+use App\Entities\Image;
+use App\Models\ImageModel;
+use Faker\Generator;
+
+class ImageFactory extends ImageModel
+{
+    /**
+     * Factory method to create a fake posts for testing.
+     */
+    public function fake(Generator &$faker): Image
+    {
+        return new Image([
+            'user_id'    => null,
+            'thread_id'  => null,
+            'post_id'    => null,
+            'name'       => $faker->regexify('[0-9]{10}_[a-z0-9]{20}') . '.jpg',
+            'size'       => rand(100000, 2000000),
+            'is_used'    => 0,
+            'ip_address' => $faker->ipv4,
+        ]);
+    }
+}

--- a/app/Models/ImageModel.php
+++ b/app/Models/ImageModel.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use App\Entities\Image;
+use CodeIgniter\Model;
+
+class ImageModel extends Model
+{
+    protected $table            = 'images';
+    protected $primaryKey       = 'id';
+    protected $useAutoIncrement = true;
+    protected $returnType       = Image::class;
+    protected $useSoftDeletes   = false;
+    protected $protectFields    = true;
+    protected $allowedFields    = ['user_id', 'thread_id', 'post_id', 'name', 'size', 'is_used'];
+
+    // Dates
+    protected $useTimestamps = true;
+
+    /**
+     * Find new images for user or already assigned to the given thread/post.
+     */
+    public function findForCheck(int $userId, int $threadId, ?int $postId = null)
+    {
+        return $this
+            ->where('user_id', $userId)
+            ->groupStart()
+                ->groupStart()
+                    ->where('thread_id', $threadId)
+                    ->where('post_id', $postId)
+                ->groupEnd()
+                ->orWhere('thread_id', null)
+            ->groupEnd()
+            ->find();
+    }
+}

--- a/app/Models/ImageModel.php
+++ b/app/Models/ImageModel.php
@@ -26,11 +26,11 @@ class ImageModel extends Model
         return $this
             ->where('user_id', $userId)
             ->groupStart()
-                ->groupStart()
-                    ->where('thread_id', $threadId)
-                    ->where('post_id', $postId)
-                ->groupEnd()
-                ->orWhere('thread_id', null)
+            ->groupStart()
+            ->where('thread_id', $threadId)
+            ->where('post_id', $postId)
+            ->groupEnd()
+            ->orWhere('thread_id', null)
             ->groupEnd()
             ->find();
     }

--- a/app/Models/PostModel.php
+++ b/app/Models/PostModel.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Concerns\HasAuthorsAndEditors;
+use App\Concerns\HasImages;
 use App\Concerns\ImpactsCategoryCounts;
 use App\Concerns\ImpactsUserActivity;
 use App\Entities\Post;
@@ -13,6 +14,7 @@ class PostModel extends Model
     use ImpactsCategoryCounts;
     use ImpactsUserActivity;
     use HasAuthorsAndEditors;
+    use HasImages;
 
     protected $table            = 'posts';
     protected $primaryKey       = 'id';
@@ -24,9 +26,9 @@ class PostModel extends Model
         'category_id', 'thread_id', 'reply_to', 'author_id', 'editor_id', 'edited_at', 'edited_reason', 'body', 'ip_address', 'include_sig', 'visible', 'markup',
     ];
     protected $useTimestamps = true;
-    protected $afterInsert   = ['incrementPostCount', 'touchThread', 'touchUser'];
+    protected $afterInsert   = ['updatePostImages', 'incrementPostCount', 'touchThread', 'touchUser'];
     protected $afterDelete   = ['decrementPostCount'];
-    protected $afterUpdate   = ['touchThread'];
+    protected $afterUpdate   = ['updatePostImages', 'touchThread'];
 
     /**
      * Scope method to only return visible posts.

--- a/app/Models/PostModel.php
+++ b/app/Models/PostModel.php
@@ -25,10 +25,11 @@ class PostModel extends Model
     protected $allowedFields    = [
         'category_id', 'thread_id', 'reply_to', 'author_id', 'editor_id', 'edited_at', 'edited_reason', 'body', 'ip_address', 'include_sig', 'visible', 'markup',
     ];
-    protected $useTimestamps = true;
-    protected $afterInsert   = ['updatePostImages', 'incrementPostCount', 'touchThread', 'touchUser'];
-    protected $afterDelete   = ['decrementPostCount'];
-    protected $afterUpdate   = ['updatePostImages', 'touchThread'];
+    protected $useTimestamps        = true;
+    protected $cleanValidationRules = false;
+    protected $afterInsert          = ['updatePostImages', 'incrementPostCount', 'touchThread', 'touchUser'];
+    protected $afterDelete          = ['decrementPostCount'];
+    protected $afterUpdate          = ['updatePostImages', 'touchThread'];
 
     /**
      * Scope method to only return visible posts.

--- a/app/Models/ThreadModel.php
+++ b/app/Models/ThreadModel.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Concerns\HasAuthorsAndEditors;
+use App\Concerns\HasImages;
 use App\Concerns\HasTags;
 use App\Concerns\ImpactsCategoryCounts;
 use App\Concerns\ImpactsUserActivity;
@@ -18,6 +19,7 @@ class ThreadModel extends Model
     use ImpactsUserActivity;
     use HasAuthorsAndEditors;
     use HasTags;
+    use HasImages;
 
     protected $table            = 'threads';
     protected $primaryKey       = 'id';
@@ -31,9 +33,9 @@ class ThreadModel extends Model
     protected $useTimestamps        = true;
     protected $cleanValidationRules = false;
     protected $beforeInsert         = ['generateSlug'];
-    protected $afterInsert          = ['incrementThreadCount', 'touchCategory', 'touchUser'];
+    protected $afterInsert          = ['updateThreadImages', 'incrementThreadCount', 'touchCategory', 'touchUser'];
     protected $afterDelete          = ['decrementThreadCount'];
-    protected $afterUpdate          = ['touchCategory', 'recalculateStats'];
+    protected $afterUpdate          = ['updateThreadImages', 'touchCategory', 'recalculateStats'];
     protected ?int $oldCategoryId   = null;
 
     /**

--- a/app/Routes.php
+++ b/app/Routes.php
@@ -31,6 +31,9 @@ $routes->post('posts/preview', 'Discussions\PostController::preview', ['as' => '
 $routes->get('posts/(:num)/show', 'Discussions\PostController::show/$1', ['as' => 'post-show']);
 $routes->get('posts/replies/(:num)', 'Discussions\PostController::allReplies/$1', ['as' => 'post-replies-load']);
 
+// Image upload
+$routes->post('images/upload', 'Discussions\ImageController::upload');
+
 // Members
 $routes->get('members', 'Members\MemberController::list');
 $routes->get('members/(:segment)', 'Members\MemberController::profile/$1', ['as' => 'profile']);

--- a/themes/default/js/components/markdownEditor.js
+++ b/themes/default/js/components/markdownEditor.js
@@ -4,6 +4,10 @@ export function initEditor(elem) {
   const easyMDE = new EasyMDE({
     element: elem,
     toolbar: ["heading", "bold", "italic", "|", "quote", "code", "link", "|", "unordered-list", "ordered-list"],
+    uploadImage: true,
+    imageMaxSize: 1024 * 1024 * 2,
+    imageAccept: ['image/png', 'image/jpeg'],
+    imageUploadEndpoint: '/images/upload',
   });
 
   easyMDE.codemirror.on("change", () => {


### PR DESCRIPTION
This PR adds support for attaching images to the threads and posts.

I resigned from other types of files since no one reasonably would download a ZIP file from a stranger. Larger projects can be hosted on GitHub or Gist.

I took the approach of making all the files publicly available. Therefore there is no option to restrict access to the files. I find it reasonable since no one should send any sensitive data, and requiring to log in to see the images was never a standard in our forum.

More info can be found in `images.md` file.