### PR TITLE
Disable callbacks for Concerns

### DIFF
--- a/app/Concerns/HasImages.php
+++ b/app/Concerns/HasImages.php
@@ -22,7 +22,7 @@ trait HasImages
         $threadId = is_array($eventData['id']) ? (int) $eventData['id'][0] : (int) $eventData['id'];
 
         $imageModel = model(ImageModel::class);
-        $images     = $imageModel->findForCheck($eventData['data']['author_id'], $threadId);
+        $images     = $imageModel->allowCallbacks(false)->findForCheck($eventData['data']['author_id'], $threadId);
 
         if (! $images) {
             return $eventData;
@@ -38,7 +38,7 @@ trait HasImages
             }
         }
 
-        $imageModel->updateBatch($images, 'id');
+        $imageModel->allowCallbacks(false)->updateBatch($images, 'id');
 
         return $eventData;
     }
@@ -58,7 +58,7 @@ trait HasImages
         $postId = is_array($eventData['id']) ? (int) $eventData['id'][0] : (int) $eventData['id'];
 
         $imageModel = model(ImageModel::class);
-        $images     = $imageModel->findForCheck($eventData['data']['author_id'], $eventData['data']['thread_id'], $postId);
+        $images     = $imageModel->allowCallbacks(false)->findForCheck($eventData['data']['author_id'], $eventData['data']['thread_id'], $postId);
 
         if (! $images) {
             return $eventData;
@@ -75,7 +75,7 @@ trait HasImages
             }
         }
 
-        $imageModel->updateBatch($images, 'id');
+        $imageModel->allowCallbacks(false)->updateBatch($images, 'id');
 
         return $eventData;
     }

--- a/app/Concerns/ImpactsCategoryCounts.php
+++ b/app/Concerns/ImpactsCategoryCounts.php
@@ -17,7 +17,7 @@ trait ImpactsCategoryCounts
             return false;
         }
 
-        $thread = $this->find($data['id']);
+        $thread = $this->allowCallbacks(false)->find($data['id']);
 
         // Increment Category thread count
         model(CategoryModel::class)->incrementStats($thread->category_id, 'thread_count');
@@ -36,7 +36,7 @@ trait ImpactsCategoryCounts
             return false;
         }
 
-        $thread = $this->find($data['id']);
+        $thread = $this->allowCallbacks(false)->find($data['id']);
 
         // Decrement Category thread count
         model(CategoryModel::class)->decrementStats($thread->category_id, 'thread_count');
@@ -55,7 +55,7 @@ trait ImpactsCategoryCounts
             return false;
         }
 
-        $post = $this->find($data['id']);
+        $post = $this->allowCallbacks(false)->find($data['id']);
 
         // Increment Category post count
         model(CategoryModel::class)->incrementStats($post->category_id, 'post_count');
@@ -76,7 +76,7 @@ trait ImpactsCategoryCounts
             return false;
         }
 
-        $post = $this->find($data['id']);
+        $post = $this->allowCallbacks(false)->find($data['id']);
 
         // Decrement Category post count
         model(CategoryModel::class)->decrementStats($post->category_id, 'post_count');

--- a/app/Concerns/ImpactsUserActivity.php
+++ b/app/Concerns/ImpactsUserActivity.php
@@ -17,6 +17,7 @@ trait ImpactsUserActivity
         }
 
         model(UserModel::class)
+            ->allowCallbacks(false)
             ->where('id', $data['data']['author_id'])
             ->set('last_active', Time::now('UTC'))
             ->update();

--- a/app/Concerns/Sluggable.php
+++ b/app/Concerns/Sluggable.php
@@ -28,7 +28,7 @@ trait Sluggable
         $count        = 1;
         $originalSlug = $slug;
 
-        while ($this->where('slug', $slug)->first()) {
+        while ($this->allowCallbacks(false)->where('slug', $slug)->first()) {
             $slug = $originalSlug . '-' . $count;
             $count++;
         }

--- a/app/Models/ThreadModel.php
+++ b/app/Models/ThreadModel.php
@@ -132,6 +132,7 @@ class ThreadModel extends Model
         }
 
         model(CategoryModel::class)
+            ->allowCallbacks(false)
             ->where('id', $data['data']['category_id'])
             ->set('last_thread_id', $data['id'])
             ->update();
@@ -167,12 +168,13 @@ class ThreadModel extends Model
         $categoryModel = model(CategoryModel::class);
 
         // Update stats for new category
-        $newCategory = $categoryModel->find($data['data']['category_id']);
+        $newCategory = $categoryModel->allowCallbacks(false)->find($data['data']['category_id']);
         $newCategory->thread_count++;
         $newCategory->post_count += $data['data']['post_count'];
 
         // Update the last_thread_id for new category
         $oldestThread = $this
+            ->allowCallbacks(false)
             ->where('category_id', $newCategory->id)
             ->orderBy('created_at', 'desc')
             ->first();
@@ -181,16 +183,17 @@ class ThreadModel extends Model
             $newCategory->last_thread_id = $oldestThread->id;
         }
 
-        $categoryModel->save($newCategory);
+        $categoryModel->allowCallbacks(false)->save($newCategory);
 
         // Update stats for old category
-        $oldCategory = $categoryModel->find($this->oldCategoryId);
+        $oldCategory = $categoryModel->allowCallbacks(false)->find($this->oldCategoryId);
         $oldCategory->thread_count--;
         $oldCategory->post_count -= $data['data']['post_count'];
 
         // Update the last_thread_id for old category
         if ($oldCategory->last_thread_id === $data['id'][0]) {
             $oldestThread = $this
+                ->allowCallbacks(false)
                 ->where('category_id', $oldCategory->id)
                 ->orderBy('created_at', 'desc')
                 ->first();
@@ -198,7 +201,7 @@ class ThreadModel extends Model
             $oldCategory->last_thread_id = $oldestThread->id;
         }
 
-        $categoryModel->save($oldCategory);
+        $categoryModel->allowCallbacks(false)->save($oldCategory);
 
         return $data;
     }


### PR DESCRIPTION
This PR disables callbacks in all `Concerns` and methods used exclusively as`callbacks`.

If the method is used as a callback, then triggering any other callback when running the callback is unnecessary. It might lead to a situation where we will be making unnecessary queries.

For that reason, we should disable callbacks in these types of methods unless using the callback actually brings some value.