### PR TITLE
feat: notifications

### DIFF
--- a/app/Config/Events.php
+++ b/app/Config/Events.php
@@ -2,6 +2,9 @@
 
 namespace Config;
 
+use App\Entities\Post;
+use App\Entities\Thread;
+use App\Events\NewPostEvent;
 use CodeIgniter\Events\Events;
 use CodeIgniter\Exceptions\FrameworkException;
 use CodeIgniter\HotReloader\HotReloader;
@@ -52,4 +55,11 @@ Events::on('pre_system', static function () {
             });
         }
     }
+});
+
+/**
+ * Event fired after a new post is added.
+ */
+Events::on('new_post', static function (Thread $thread, Post $post) {
+    (new NewPostEvent($thread, $post))->process();
 });

--- a/app/Controllers/Account/AccountController.php
+++ b/app/Controllers/Account/AccountController.php
@@ -3,6 +3,8 @@
 namespace App\Controllers\Account;
 
 use App\Controllers\BaseController;
+use App\Entities\NotificationSetting;
+use App\Models\NotificationSettingModel;
 use App\Models\PostModel;
 
 class AccountController extends BaseController
@@ -31,6 +33,32 @@ class AccountController extends BaseController
             'user'  => auth()->user(),
             'posts' => $posts,
             'pager' => $postModel->pager,
+        ]);
+    }
+
+    /**
+     * Manage notifications about new replies
+     * for thread and posts.
+     */
+    public function notifications()
+    {
+        helper('form');
+
+        if ($this->request->is('post') && $this->validate([
+            'email_thread'     => ['required', 'in_list[0,1]'],
+            'email_post'       => ['required', 'in_list[0,1]'],
+            'email_post_reply' => ['required', 'in_list[0,1]'],
+        ])) {
+            $settings          = new NotificationSetting($this->validator->getValidated());
+            $settings->user_id = user_id();
+
+            model(NotificationSettingModel::class)->save($settings);
+        }
+
+        return $this->render('account/notifications', [
+            'user'         => auth()->user(),
+            'notification' => model(NotificationSettingModel::class)->find(user_id()),
+            'validator'    => $this->validator ?? service('validation'),
         ]);
     }
 }

--- a/app/Database/Migrations/2023-10-03-122331_AddNotificationSettingsTable.php
+++ b/app/Database/Migrations/2023-10-03-122331_AddNotificationSettingsTable.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class AddNotificationSettingsTable extends Migration
+{
+    public function up()
+    {
+        $this->forge->addField([
+            'user_id'          => ['type' => 'int', 'constraint' => 11, 'unsigned' => true],
+            'email_thread'     => ['type' => 'tinyint', 'constraint' => 1, 'unsigned' => true, 'null' => false, 'default' => 0],
+            'email_post'       => ['type' => 'tinyint', 'constraint' => 1, 'unsigned' => true, 'null' => false, 'default' => 0],
+            'email_post_reply' => ['type' => 'tinyint', 'constraint' => 1, 'unsigned' => true, 'null' => false, 'default' => 0],
+            'created_at'       => ['type' => 'datetime', 'null' => false],
+            'updated_at'       => ['type' => 'datetime', 'null' => false],
+        ]);
+        $this->forge->addForeignKey('user_id', 'users', 'id', '', 'delete');
+        $this->forge->addUniqueKey('user_id');
+        $this->forge->createTable('notification_settings', true);
+    }
+
+    public function down()
+    {
+        $this->forge->dropTable('notification_settings', true);
+    }
+}

--- a/app/Entities/NotificationSetting.php
+++ b/app/Entities/NotificationSetting.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Entities;
+
+use CodeIgniter\Entity\Entity;
+
+class NotificationSetting extends Entity
+{
+    protected $datamap = [];
+    protected $dates   = ['created_at', 'updated_at'];
+    protected $casts   = [
+        'user_id'          => 'integer',
+        'email_thread'     => 'int-bool',
+        'email_post'       => 'int-bool',
+        'email_post_reply' => 'int-bool',
+    ];
+}

--- a/app/Events/NewPostEvent.php
+++ b/app/Events/NewPostEvent.php
@@ -10,8 +10,21 @@ use App\Models\PostModel;
 
 class NewPostEvent
 {
+    /**
+     * Number of notifications sent.
+     */
+    private int $count = 0;
+
     public function __construct(protected Thread $thread, protected Post $post)
     {
+    }
+
+    /**
+     * Get number of notifications sent.
+     */
+    public function getCount(): int
+    {
+        return $this->count;
     }
 
     /**
@@ -60,6 +73,8 @@ class NewPostEvent
             return false;
         }
 
+        $this->count++;
+
         // send notification
         return $this->sendNotification($this->thread->author, $this->thread, $this->post);
     }
@@ -100,6 +115,7 @@ class NewPostEvent
             if ($setting->email_post === true) {
                 // send notification
                 $this->sendNotification($this->post->author, $this->thread, $this->post);
+                $this->count++;
 
                 continue;
             }
@@ -110,6 +126,7 @@ class NewPostEvent
                 if ($postReplyTo?->author_id === $setting->user_id) {
                     // send notification
                     $this->sendNotification($this->post->author, $this->thread, $this->post);
+                    $this->count++;
 
                     continue;
                 }
@@ -118,10 +135,11 @@ class NewPostEvent
                 if (in_array($setting->user_id, $replyAuthorIds, true)) {
                     // send notification
                     $this->sendNotification($this->post->author, $this->thread, $this->post);
+                    $this->count++;
                 }
             }
         }
 
-        return true;
+        return $this->count > 0;
     }
 }

--- a/app/Events/NewPostEvent.php
+++ b/app/Events/NewPostEvent.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Events;
+
+use App\Entities\Post;
+use App\Entities\Thread;
+use App\Entities\User;
+use App\Models\NotificationSettingModel;
+use App\Models\PostModel;
+
+class NewPostEvent
+{
+    public function __construct(protected Thread $thread, protected Post $post)
+    {
+    }
+
+    /**
+     * Process event.
+     */
+    public function process(): void
+    {
+        if ($this->thread->author_id !== $this->post->author_id) {
+            // prepare notification settings for thread author
+            $this->handleThreadNotifications();
+        }
+
+        // prepare notification settings for post authors
+        $this->handlePostNotifications();
+    }
+
+    /**
+     * Send email notification.
+     *
+     * @todo Make it run in the background (queueNotification).
+     */
+    private function sendNotification(User $recipient, Thread $thread, Post $post): bool
+    {
+        helper('text');
+
+        return service('email', false)
+            ->setFrom('notifications@myth.forum', config('App')->siteName)
+            ->setTo($recipient->email)
+            ->setSubject(config('App')->siteName . ' - New post notification')
+            ->setMessage(view('_emails/new_post', [
+                'user' => $recipient, 'thread' => $thread, 'post' => $post,
+            ]))
+            ->send();
+    }
+
+    /**
+     * Handle thread related notifications.
+     */
+    private function handleThreadNotifications(): bool
+    {
+        $notifications = model(NotificationSettingModel::class)
+            ->withThreadNotification()
+            ->find($this->thread->author_id);
+
+        if (empty($notifications)) {
+            return false;
+        }
+
+        // send notification
+        return $this->sendNotification($this->thread->author, $this->thread, $this->post);
+    }
+
+    /**
+     * Handle post related notifications.
+     */
+    private function handlePostNotifications(): bool
+    {
+        $postModel = model(PostModel::class);
+
+        // get all post authors except the current on
+        $authorIds = $postModel->getAuthorIds($this->thread->id, [$this->post->author_id]);
+
+        if (empty($authorIds)) {
+            return false;
+        }
+
+        // get notification settings for the post authors
+        $notifications = model(NotificationSettingModel::class)->withPostNotification()->find($authorIds);
+
+        if (empty($notifications)) {
+            return false;
+        }
+
+        // if we deal with the reply_to post type get the main post
+        $postReplyTo = $this->post->reply_to !== null ?
+            $postModel->find($this->post->reply_to) :
+            null;
+        // get authors of all replies for the main post
+        $replyAuthorIds = $postReplyTo !== null ?
+            $postModel->getReplyAuthorIds($this->post->reply_to, [$this->post->author_id]) :
+            [];
+
+        // check users notifications
+        foreach ($notifications as $setting) {
+            // user wants to be notified about every reply
+            if ($setting->email_post === true) {
+                // send notification
+                $this->sendNotification($this->post->author, $this->thread, $this->post);
+
+                continue;
+            }
+
+            // user wants to be notified about replies to his posts only
+            if ($setting->email_post_reply === true) {
+                // direct reply to the post author
+                if ($postReplyTo?->author_id === $setting->user_id) {
+                    // send notification
+                    $this->sendNotification($this->post->author, $this->thread, $this->post);
+
+                    continue;
+                }
+
+                // user replied to the same post earlier
+                if (in_array($setting->user_id, $replyAuthorIds, true)) {
+                    // send notification
+                    $this->sendNotification($this->post->author, $this->thread, $this->post);
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/app/Events/NewPostEvent.php
+++ b/app/Events/NewPostEvent.php
@@ -86,7 +86,7 @@ class NewPostEvent
     {
         $postModel = model(PostModel::class);
 
-        // get all post authors except the current on
+        // get all post authors except the current one
         $authorIds = $postModel->getAuthorIds($this->thread->id, [$this->post->author_id]);
 
         if (empty($authorIds)) {

--- a/app/Models/Factories/NotificationSettingFactory.php
+++ b/app/Models/Factories/NotificationSettingFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models\Factories;
+
+use App\Entities\NotificationSetting;
+use App\Models\NotificationSettingModel;
+use Faker\Generator;
+
+class NotificationSettingFactory extends NotificationSettingModel
+{
+    /**
+     * Factory method to create a fake notification settings.
+     */
+    public function fake(Generator &$faker): NotificationSetting
+    {
+        return new NotificationSetting([
+            'user_id'          => null,
+            'email_thread'     => 0,
+            'email_post'       => 0,
+            'email_post_reply' => 0,
+        ]);
+    }
+}

--- a/app/Models/NotificationSettingModel.php
+++ b/app/Models/NotificationSettingModel.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use App\Entities\NotificationSetting;
+use CodeIgniter\Model;
+
+class NotificationSettingModel extends Model
+{
+    protected $table            = 'notification_settings';
+    protected $primaryKey       = 'user_id';
+    protected $useAutoIncrement = false;
+    protected $returnType       = NotificationSetting::class;
+    protected $useSoftDeletes   = false;
+    protected $protectFields    = true;
+    protected $allowedFields    = ['user_id', 'email_thread', 'email_post', 'email_post_reply'];
+
+    // Dates
+    protected $useTimestamps = true;
+
+    /**
+     * Get settings with active email thread notifications.
+     */
+    public function withThreadNotification()
+    {
+        $this->where('email_thread', 1);
+
+        return $this;
+    }
+
+    /**
+     * Get settings with active email post notifications.
+     */
+    public function withPostNotification()
+    {
+        $this->groupStart()->where('email_post', 1)->orWhere('email_post_reply', 1)->groupEnd();
+
+        return $this;
+    }
+}

--- a/app/Models/PostModel.php
+++ b/app/Models/PostModel.php
@@ -147,6 +147,40 @@ class PostModel extends Model
     }
 
     /**
+     * Get all users ids for people who posted a reply to a given thread.
+     */
+    public function getAuthorIds(int $threadId, array $excludeUsers = []): array
+    {
+        $authors = $this->builder()
+            ->distinct()
+            ->select('author_id')
+            ->where('thread_id', $threadId)
+            ->whereNotIn('author_id', $excludeUsers)
+            ->where('visible', true)
+            ->get()
+            ->getResultArray();
+
+        return array_map('intval', array_column($authors, 'author_id'));
+    }
+
+    /**
+     * Get all users ids for people who posted a reply to a given post.
+     */
+    public function getReplyAuthorIds(int $replyTo, array $excludeUsers = []): array
+    {
+        $authors = $this->builder()
+            ->distinct()
+            ->select('author_id')
+            ->where('reply_to', $replyTo)
+            ->whereNotIn('author_id', $excludeUsers)
+            ->where('visible', true)
+            ->get()
+            ->getResultArray();
+
+        return array_map('intval', array_column($authors, 'author_id'));
+    }
+
+    /**
      * Update the category's last_thread_id.
      */
     protected function touchThread(array $data)

--- a/app/Models/UserModel.php
+++ b/app/Models/UserModel.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Concerns\HasStats;
 use App\Entities\User;
 use CodeIgniter\Shield\Models\UserModel as ShieldUser;
+use ReflectionException;
 
 class UserModel extends ShieldUser
 {
@@ -20,6 +21,9 @@ class UserModel extends ShieldUser
         $this->allowedFields = array_merge($this->allowedFields, [
             'handed', 'thread_count', 'post_count', 'avatar', 'country', 'timezone', 'name', 'company', 'location', 'website', 'signature',
         ]);
+
+        // Add event after insert
+        $this->afterInsert[] = 'createNotificationSettings';
     }
 
     public function searchMembers(array $search, int $page, int $perPage, string $sortColumn, string $sortDirection): ?array
@@ -79,5 +83,17 @@ class UserModel extends ShieldUser
         }
 
         return $results;
+    }
+
+    /**
+     * Create default notification settings for user.
+     *
+     * @throws ReflectionException
+     */
+    protected function createNotificationSettings(array $eventData): void
+    {
+        if ($eventData['result']) {
+            model(NotificationSettingModel::class)->insert(['user_id' => $eventData['id']]);
+        }
     }
 }

--- a/app/Routes.php
+++ b/app/Routes.php
@@ -45,6 +45,7 @@ $routes->get('display-error', 'ErrorController::general', ['as' => 'general-erro
 $routes->group('account', ['filter'], static function (RouteCollection $routes) {
     $routes->get('/', 'Account\AccountController::index', ['as' => 'account']);
     $routes->get('posts', 'Account\AccountController::posts', ['as' => 'account-posts']);
+    $routes->match(['get', 'post'], 'notifications', 'Account\AccountController::notifications', ['as' => 'account-notifications']);
 });
 
 // Shield Auth routes

--- a/app/Views/_emails/new_post.php
+++ b/app/Views/_emails/new_post.php
@@ -1,0 +1,13 @@
+Hi <?= esc($user->username) ?>,
+
+<br><br>
+
+There is a new reply in the thread: <strong><?= esc($thread->title) ?></strong>
+
+<br><br>
+
+<strong><?= esc($post->author->username) ?></strong> on <?= $post->created_at->format('F d, Y g:ia') ?> wrote:
+
+<br><br>
+
+<i><?= ellipsize($post->render(), 50) ?></i>

--- a/app/Views/account/_nav.php
+++ b/app/Views/account/_nav.php
@@ -12,7 +12,7 @@
         ],
         [
             'title' => 'Notifications',
-            'url'   => '',
+            'url'   => route_to('account-notifications'),
             'icon'  => view('icons/bell'),
         ],
         [

--- a/app/Views/account/notifications.php
+++ b/app/Views/account/notifications.php
@@ -1,0 +1,76 @@
+<?= $this->extend('master')  ?>
+
+<?= $this->section('header') ?>
+<?= view('account/_header', ['user' => $user]) ?>
+<?= $this->endSection() ?>
+
+
+<?= $this->section('main')  ?>
+<?= view('account/_post-head', [
+    'title' => 'Notifications',
+    'subTitle' => 'Your notification settings for discussions and new posts.'
+]) ?>
+
+<?= form_open(); ?>
+<h6 class="border-solid border-b-2 mt-6">Threads</h6>
+<div class="form-control">
+    <label class="label cursor-pointer flex">
+        <input type="hidden" name="email_thread" value="0">
+        <input type="checkbox" name="email_thread" value="1" <?= set_checkbox('email_thread', '1', $notification->email_thread) ?>
+               class="toggle toggle-primary">
+        <span class="label-text ml-2 flex-auto">Send a notification for every new post in the thread I created</span>
+    </label>
+    <?php if ($validator->hasError('email_thread')): ?>
+        <label class="label">
+            <span class="label-text-alt text-red-600"><?= $validator->getError('email_thread'); ?></span>
+        </label>
+    <?php endif; ?>
+</div>
+
+<h6 class="border-solid border-b-2 mt-6">Posts</h6>
+<div x-data="{ checkboxEmailPost: <?= $notification->email_post ? 'true' : 'false' ?>, checkboxEmailPostReply: <?= $notification->email_post_reply ? 'true' : 'false' ?> }">
+    <div class="form-control">
+        <label class="label cursor-pointer flex">
+            <input type="hidden" name="email_post" value="0">
+            <input type="checkbox" name="email_post" value="1" <?= set_checkbox('email_post', '1', $notification->email_post) ?>
+                   class="toggle toggle-primary"
+                   x-model="checkboxEmailPost" @click="checkboxEmailPostReply = false">
+            <span class="label-text ml-2 flex-auto">Send a notification for every new post in a thread in which I participated</span>
+        </label>
+        <?php if ($validator->hasError('email_post')): ?>
+            <label class="label">
+                <span class="label-text-alt text-red-600"><?= $validator->getError('email_post'); ?></span>
+            </label>
+        <?php endif; ?>
+    </div>
+    <div class="form-control">
+        <label class="label cursor-pointer flex">
+            <input type="hidden" name="email_post_reply" value="0">
+            <input type="checkbox" name="email_post_reply" value="1" <?= set_checkbox('email_post_reply', '1', $notification->email_post_reply) ?>
+                   class="toggle toggle-primary"
+                   x-model="checkboxEmailPostReply" @click="checkboxEmailPost = false">
+            <span class="label-text ml-2 flex-auto">Send a notification only for posts that are replies to my post</span>
+        </label>
+        <?php if ($validator->hasError('email_post_reply')): ?>
+            <label class="label">
+                <span class="label-text-alt text-red-600"><?= $validator->getError('email_post_reply'); ?></span>
+            </label>
+        <?php endif; ?>
+    </div>
+</div>
+
+<div class="flex justify-center mt-6">
+    <div class="btn-group btn-group-horizontal w-full">
+        <button type="submit" class="btn btn-primary w-full" data-loading-disable>
+            Save
+        </button>
+    </div>
+</div>
+<?= form_close(); ?>
+
+<?= $this->endSection() ?>
+
+
+<?= $this->section('sidebar')  ?>
+<?= view('account/_sidebar') ?>
+<?= $this->endSection() ?>

--- a/app/Views/account/notifications.php
+++ b/app/Views/account/notifications.php
@@ -7,7 +7,7 @@
 
 <?= $this->section('main')  ?>
 <?= view('account/_post-head', [
-    'title' => 'Notifications',
+    'title' => 'My Notifications',
     'subTitle' => 'Your notification settings for discussions and new posts.'
 ]) ?>
 

--- a/tests/Controllers/AccountControllerTest.php
+++ b/tests/Controllers/AccountControllerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Controllers;
+
+use App\Models\Factories\UserFactory;
+use Exception;
+use Tests\Support\TestCase;
+
+/**
+ * @internal
+ */
+final class AccountControllerTest extends TestCase
+{
+    /**
+     * @throws Exception
+     */
+    public function testShowPosts()
+    {
+        $user = fake(UserFactory::class, [
+            'username' => 'testuser',
+        ]);
+        $user->addGroup('user');
+        $response = $this->actingAs($user)->get('account/posts');
+
+        $response->assertOK();
+        $response->assertSeeElement('h2');
+        $response->assertSee('My Posts');
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testShowNotifications()
+    {
+        $user = fake(UserFactory::class, [
+            'username' => 'testuser',
+        ]);
+        $user->addGroup('user');
+        $response = $this->actingAs($user)->get('account/notifications');
+
+        $response->assertOK();
+        $response->assertSeeElement('h2');
+        $response->assertSee('My Notifications');
+    }
+
+    public function testUpdateNotifications()
+    {
+        $user = fake(UserFactory::class, [
+            'username' => 'testuser',
+        ]);
+        $user->addGroup('user');
+        $response = $this->actingAs($user)->post('account/notifications', [
+            'email_thread'     => 1,
+            'email_post'       => 0,
+            'email_post_reply' => 0,
+        ]);
+
+        $response->assertOK();
+        $response->assertSeeElement('h2');
+        $response->assertSee('My Notifications');
+
+        $this->seeInDatabase('notification_settings', [
+            'user_id'          => $user->id,
+            'email_thread'     => 1,
+            'email_post'       => 0,
+            'email_post_reply' => 0,
+        ]);
+    }
+}

--- a/tests/Events/NewPostEventTest.php
+++ b/tests/Events/NewPostEventTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use App\Entities\Post;
+use App\Entities\Thread;
+use App\Events\NewPostEvent;
+use App\Models\Factories\PostFactory;
+use App\Models\Factories\UserFactory;
+use App\Models\NotificationSettingModel;
+use App\Models\PostModel;
+use App\Models\ThreadModel;
+use CodeIgniter\Test\ReflectionHelper;
+use Tests\Support\Database\Seeds\TestDataSeeder;
+use Tests\Support\TestCase;
+
+/**
+ * @internal
+ */
+final class NewPostEventTest extends TestCase
+{
+    use ReflectionHelper;
+
+    protected $seed = TestDataSeeder::class;
+
+    /**
+     * @dataProvider provideHandleThreadNotifications
+     * @throws ReflectionException
+     */
+    public function testHandleThreadNotifications(int $emailThread, bool $result, int $count)
+    {
+        $user = fake(UserFactory::class, [
+            'username' => 'testuser',
+        ]);
+        $user->addGroup('user');
+
+        $post = fake(PostFactory::class, [
+            'category_id' => 1,
+            'thread_id'   => 1,
+            'author_id'   => $user->id,
+        ]);
+        /** @var Post $post */
+        $post   = model(PostModel::class)->withUsers($post);
+        $thread = model(ThreadModel::class)->find(1);
+        /** @var Thread $thread */
+        $thread = model(ThreadModel::class)->withUsers($thread);
+
+        model(NotificationSettingModel::class)->save([
+            'user_id'      => 1,
+            'email_thread' => $emailThread,
+        ]);
+
+        $event  = new NewPostEvent($thread, $post);
+        $method = $this->getPrivateMethodInvoker($event, 'handleThreadNotifications');
+        $this->assertSame($result, $method());
+        $this->assertSame($event->getCount(), $count);
+    }
+
+    public static function provideHandleThreadNotifications(): iterable
+    {
+        yield [1, true, 1];
+
+        yield [0, false, 0];
+    }
+
+    /**
+     * @dataProvider provideHandlePostNotifications
+     * @throws ReflectionException
+     */
+    public function testHandlePostNotifications(bool $addPost1, bool $replyTo, ?int $userId, int $emailPost, int $emailPostReply, bool $result, int $count)
+    {
+        $user = fake(UserFactory::class, [
+            'username' => 'testuser',
+        ]);
+        $user->addGroup('user');
+
+        $post1 = null;
+        if ($addPost1) {
+            // post 1
+            /** @var Post $post1 */
+            $post1 = fake(PostFactory::class, [
+                'category_id' => 1,
+                'thread_id'   => 1,
+                'author_id'   => 1,
+            ]);
+        }
+
+        // post 2
+        $post2 = fake(PostFactory::class, [
+            'category_id' => 1,
+            'thread_id'   => 1,
+            'author_id'   => $user->id,
+            'reply_to'    => $replyTo ? $post1?->id : null,
+        ]);
+        /** @var Post $post2 */
+        $post2 = model(PostModel::class)->withUsers($post2);
+
+        $thread = model(ThreadModel::class)->find(1);
+        /** @var Thread $thread */
+        $thread = model(ThreadModel::class)->withUsers($thread);
+
+        model(NotificationSettingModel::class)->save([
+            'user_id'          => $userId ?? $user->id,
+            'email_post'       => $emailPost,
+            'email_post_reply' => $emailPostReply,
+        ]);
+
+        $event  = new NewPostEvent($thread, $post2);
+        $method = $this->getPrivateMethodInvoker($event, 'handlePostNotifications');
+        $this->assertSame($result, $method());
+        $this->assertSame($event->getCount(), $count);
+    }
+
+    public static function provideHandlePostNotifications(): iterable
+    {
+        yield [false, false, null, 0, 0, false, 0];
+
+        yield [true, false, null, 0, 0, false, 0];
+
+        yield [true, false, 1, 1, 0, true, 1];
+
+        yield [true, false, 1, 0, 1, false, 0];
+
+        yield [true, true, 1, 0, 1, true, 1];
+    }
+}


### PR DESCRIPTION
This PR adds some notification options about new posts.

I thought it would be useful to make it as simple as possible, that is, only the main settings for notifications - without signing up for them when creating a post/thread.

What do you guys think about the current types of notifications? Is it too much, or is something missing?

To do:
* add a link to open the discussion/post from email in the browser
* provide a link to opt out of notifications for a given thread in email
* add a queue system for sending emails (probably based on the DB since this is our only available option?)

But what I have listed above, I will add in separate PRs in the future.