### PR TITLE
Add link to view the post from the notification

### DIFF
--- a/_docs/start.md
+++ b/_docs/start.md
@@ -36,3 +36,8 @@ We use [ParcelJS]() to handle compiling the frontend assets, including SASS and 
 ```cli
 npm run dev
 ```
+
+## Sending emails
+
+Setup some Email Sandbox. Provide credentials - preferably using the `.env` file. 
+Don't forget to set up `fromEmail` and `fromName` variables too, because without them emails won't be sent.

--- a/app/Config/Events.php
+++ b/app/Config/Events.php
@@ -2,6 +2,7 @@
 
 namespace Config;
 
+use App\Entities\Category;
 use App\Entities\Post;
 use App\Entities\Thread;
 use App\Events\NewPostEvent;
@@ -60,6 +61,6 @@ Events::on('pre_system', static function () {
 /**
  * Event fired after a new post is added.
  */
-Events::on('new_post', static function (Thread $thread, Post $post) {
-    (new NewPostEvent($thread, $post))->process();
+Events::on('new_post', static function (Category $category, Thread $thread, Post $post) {
+    (new NewPostEvent($category, $thread, $post))->process();
 });

--- a/app/Controllers/Discussions/DiscussionController.php
+++ b/app/Controllers/Discussions/DiscussionController.php
@@ -191,7 +191,7 @@ class DiscussionController extends BaseController
         $pager  = $postModel->pager->only(['page']);
 
         return $this->render('discussions/thread', [
-            'slug' => $slug, 'thread' => $thread, 'posts' => $posts,
+            'slug'  => $slug, 'thread' => $thread, 'posts' => $posts,
             'pager' => $pager, 'loadedReplies' => $loadedReplies ?? [],
         ]);
     }

--- a/app/Entities/Post.php
+++ b/app/Entities/Post.php
@@ -12,6 +12,7 @@ class Post extends Entity
     protected $datamap = [];
     protected $dates   = ['created_at', 'updated_at', 'deleted_at', 'edited_at'];
     protected $casts   = [
+        'id'          => 'integer',
         'category_id' => 'integer',
         'thread_id'   => 'integer',
         'reply_to'    => '?integer',
@@ -24,12 +25,17 @@ class Post extends Entity
     /**
      * Returns a link to this post's page for use in views.
      */
-    public function link()
+    public function link(?Category $category = null, ?Thread $thread = null)
     {
-        $categorySlug = model('CategoryModel')->find($this->category_id)->slug;
-        $threadSlug   = model('ThreadModel')->find($this->thread_id)->slug;
+        $categorySlug = $category === null ?
+            model('CategoryModel')->find($this->category_id)->slug :
+            $category->slug;
 
-        return route_to('post', $categorySlug, $threadSlug, $this->id);
+        $threadSlug = $thread === null ?
+            model('ThreadModel')->find($this->thread_id)->slug :
+            $thread->slug;
+
+        return site_url(route_to('post', $categorySlug, $threadSlug, $this->id)) . '#post-' . $this->id;
     }
 
     public function setReplyTo(?string $value = null)

--- a/app/Events/NewPostEvent.php
+++ b/app/Events/NewPostEvent.php
@@ -16,6 +16,7 @@ class NewPostEvent
      * Number of notifications sent.
      */
     private int $count = 0;
+
     private array $notifiedUsers = [];
 
     public function __construct(protected Category $category, protected Thread $thread, protected Post $post)

--- a/app/Events/NewPostEvent.php
+++ b/app/Events/NewPostEvent.php
@@ -51,7 +51,6 @@ class NewPostEvent
         helper('text');
 
         return service('email', false)
-            ->setFrom('notifications@myth.forum', config('App')->siteName)
             ->setTo($recipient->email)
             ->setSubject(config('App')->siteName . ' - New post notification')
             ->setMessage(view('_emails/new_post', [

--- a/app/Models/PostModel.php
+++ b/app/Models/PostModel.php
@@ -151,7 +151,6 @@ class PostModel extends Model
      */
     public function getPageNumberForPost(int $threadId, int $postId, int $perPage = 10): ?int
     {
-        //$sql = "SELECT COUNT(*) as position FROM your_table WHERE postId <= ? ORDER BY postId";
         $result = $this->builder()
             ->select('COUNT(*) AS position')
             ->where('thread_id', $threadId)

--- a/app/Routes.php
+++ b/app/Routes.php
@@ -21,6 +21,7 @@ $routes->match(['get', 'post'], 'discussions/new', 'Discussions\ThreadController
 $routes->match(['get', 'put'], 'discussions/(:num)/edit', 'Discussions\ThreadController::edit/$1', ['as' => 'thread-edit']);
 $routes->post('discussions/preview', 'Discussions\ThreadController::preview', ['as' => 'thread-preview']);
 $routes->get('discussions/(:num)/show', 'Discussions\ThreadController::show/$1', ['as' => 'thread-show']);
+$routes->get('discussions/(:segment)/(:segment)?post_id=(:num)', 'Discussions\DiscussionController::thread/$2', ['as' => 'post']);
 $routes->get('discussions/(:segment)/(:segment)', 'Discussions\DiscussionController::thread/$2', ['as' => 'thread']);
 
 // Posts

--- a/app/Views/_emails/new_post.php
+++ b/app/Views/_emails/new_post.php
@@ -10,4 +10,16 @@ There is a new reply in the thread: <strong><?= esc($thread->title) ?></strong>
 
 <br><br>
 
-<i><?= ellipsize($post->render(), 50) ?></i>
+<i><?= ellipsize(strip_tags($post->render()), 50) ?></i>
+
+<br><br>
+
+You can view this discussion in your browser by clicking <a href="<?= $post->link($category, $thread) ?>">here</a>.
+
+<br><br>
+
+<small>
+    —<br>
+    You are receiving this because you are subscribed to this type of notifications.<br>
+    This behavior can be changed permanently in your <a href="<?= site_url(route_to('account-notifications')) ?>">account settings</a>.
+</small>

--- a/app/Views/discussions/_thread_items.php
+++ b/app/Views/discussions/_thread_items.php
@@ -1,3 +1,3 @@
 <?php foreach ($posts as $post) : ?>
-    <?= view('discussions/posts/_post_with_replies', ['post' => $post]) ?>
+    <?= view('discussions/posts/_post_with_replies', ['post' => $post, 'loadedReplies' => $loadedReplies]) ?>
 <?php endforeach ?>

--- a/app/Views/discussions/posts/_post.php
+++ b/app/Views/discussions/posts/_post.php
@@ -1,4 +1,4 @@
-<div class="post p-6 rounded bg-base-100 shadow-xl">
+<div class="post p-6 rounded bg-base-100 shadow-xl" id="post-<?= $post->id ?>">
     <!-- Post Meta -->
     <div class="post-meta">
         <div class="flex gap-4">

--- a/app/Views/discussions/posts/_post_with_replies.php
+++ b/app/Views/discussions/posts/_post_with_replies.php
@@ -5,20 +5,26 @@
     <!-- Replies -->
     <?php if (isset($post->replies)) : ?>
         <div class="post-replies ml-10">
-            <?php if ($post->replies_count > 2): ?>
-                <div class="my-6 text-center">
-                    <a class="btn btn-xs btn-primary"
-                       hx-get="<?= route_to('post-replies-load', $post->id); ?>"
-                       hx-target="closest .post-replies"
-                       hx-swap="innerHTML show:top"
-                    >
-                        Load previous replies
-                    </a>
-                </div>
+            <?php if (isset($loadedReplies[$post->id])): ?>
+                <?php foreach ($loadedReplies[$post->id] as $reply) : ?>
+                    <?= view('discussions/posts/_post_with_replies', ['post' => $reply]) ?>
+                <?php endforeach ?>
+            <?php else: ?>
+                <?php if ($post->replies_count > 2): ?>
+                    <div class="my-6 text-center">
+                        <a class="btn btn-xs btn-primary"
+                           hx-get="<?= route_to('post-replies-load', $post->id); ?>"
+                           hx-target="closest .post-replies"
+                           hx-swap="innerHTML show:top"
+                        >
+                            Load previous replies
+                        </a>
+                    </div>
+                <?php endif; ?>
+                <?php foreach ($post->replies as $reply) : ?>
+                    <?= view('discussions/posts/_post_with_replies', ['post' => $reply]) ?>
+                <?php endforeach ?>
             <?php endif; ?>
-            <?php foreach ($post->replies as $reply) : ?>
-                <?= view('discussions/posts/_post_with_replies', ['post' => $reply]) ?>
-            <?php endforeach ?>
         </div>
     <?php endif ?>
     <?php if ($post->reply_to === null): ?>

--- a/app/Views/discussions/thread.php
+++ b/app/Views/discussions/thread.php
@@ -27,7 +27,7 @@
                 </div>
 
                 <div id="replies-content">
-                    <?= view('discussions/_thread_items', ['posts' => $posts]) ?>
+                    <?= view('discussions/_thread_items', ['posts' => $posts, 'loadedReplies' => $loadedReplies]) ?>
                 </div>
 
                 <div id="replies-footer" class="flex justify-between">

--- a/tests/Events/NewPostEventTest.php
+++ b/tests/Events/NewPostEventTest.php
@@ -1,8 +1,10 @@
 <?php
 
+use App\Entities\Category;
 use App\Entities\Post;
 use App\Entities\Thread;
 use App\Events\NewPostEvent;
+use App\Models\CategoryModel;
 use App\Models\Factories\PostFactory;
 use App\Models\Factories\UserFactory;
 use App\Models\NotificationSettingModel;
@@ -42,13 +44,15 @@ final class NewPostEventTest extends TestCase
         $thread = model(ThreadModel::class)->find(1);
         /** @var Thread $thread */
         $thread = model(ThreadModel::class)->withUsers($thread);
+        /** @var Category $category */
+        $category = model(CategoryModel::class)->find(1);
 
         model(NotificationSettingModel::class)->save([
             'user_id'      => 1,
             'email_thread' => $emailThread,
         ]);
 
-        $event  = new NewPostEvent($thread, $post);
+        $event  = new NewPostEvent($category, $thread, $post);
         $method = $this->getPrivateMethodInvoker($event, 'handleThreadNotifications');
         $this->assertSame($result, $method());
         $this->assertSame($event->getCount(), $count);
@@ -96,6 +100,8 @@ final class NewPostEventTest extends TestCase
         $thread = model(ThreadModel::class)->find(1);
         /** @var Thread $thread */
         $thread = model(ThreadModel::class)->withUsers($thread);
+        /** @var Category $category */
+        $category = model(CategoryModel::class)->find(1);
 
         model(NotificationSettingModel::class)->save([
             'user_id'          => $userId ?? $user->id,
@@ -103,7 +109,7 @@ final class NewPostEventTest extends TestCase
             'email_post_reply' => $emailPostReply,
         ]);
 
-        $event  = new NewPostEvent($thread, $post2);
+        $event  = new NewPostEvent($category, $thread, $post2);
         $method = $this->getPrivateMethodInvoker($event, 'handlePostNotifications');
         $this->assertSame($result, $method());
         $this->assertSame($event->getCount(), $count);


### PR DESCRIPTION
This PR adds a link to the email notification, so we can go directly to the discussion and new post.

* We display the correct page if the discussion has multiple pages
* If a post was a reply to another post, we display all replies to that post