### PR TITLE
Enable CSRF

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ No guarantee is made that this repo represents a complete, working application. 
 -   [AlpineJS](https://alpinejs.dev/)
 -   [Tailwind](https://tailwindcss.com/)
 -   [DaisyUI](https://daisyui.com/)
+-   [HeroIcons](https://heroicons.com/) 
+-   [EasyMDE](https://github.com/Ionaru/easy-markdown-editor)
 
 ## Docs and Installation
 
-Documenation (what there is of it!) can be found in the [docs](_docs) folder.
+Documentation (what there is of it!) can be found in the [docs](_docs) folder.
 Installation instructions are in [docs/start.md](_docs/start.md).
 
 It may or may not be improved over time.

--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -36,7 +36,7 @@ class Filters extends BaseConfig
     public array $globals = [
         'before' => [
             // 'honeypot',
-            // 'csrf',
+            'csrf',
             // 'invalidchars',
         ],
         'after' => [

--- a/app/Config/Migrations.php
+++ b/app/Config/Migrations.php
@@ -25,9 +25,7 @@ class Migrations extends BaseConfig
      *
      * This is the name of the table that will store the current migrations state.
      * When migrations runs it will store in a database table which migration
-     * level the system is at. It then compares the migration level in this
-     * table to the $config['migration_version'] if they are not the same it
-     * will migrate up. This must be set.
+     * files have already been run.
      */
     public string $table = 'migrations';
 
@@ -40,7 +38,7 @@ class Migrations extends BaseConfig
      * using the CLI command:
      *   > php spark make:migration
      *
-     * Note: if you set an unsupported format, migration runner will not find
+     * NOTE: if you set an unsupported format, migration runner will not find
      *       your migration files.
      *
      * Supported formats:

--- a/app/Config/View.php
+++ b/app/Config/View.php
@@ -5,6 +5,10 @@ namespace Config;
 use CodeIgniter\Config\View as BaseView;
 use CodeIgniter\View\ViewDecoratorInterface;
 
+/**
+ * @phpstan-type ParserCallable (callable(mixed): mixed)
+ * @phpstan-type ParserCallableString (callable(mixed): mixed)&string
+ */
 class View extends BaseView
 {
     /**
@@ -30,7 +34,8 @@ class View extends BaseView
      *  { title|esc(js) }
      *  { created_on|date(Y-m-d)|esc(attr) }
      *
-     * @var array
+     * @var array<string, string>
+     * @phpstan-var array<string, ParserCallableString>
      */
     public $filters = [];
 
@@ -39,7 +44,8 @@ class View extends BaseView
      * by the core Parser by creating aliases that will be replaced with
      * any callable. Can be single or tag pair.
      *
-     * @var array
+     * @var array<string, array<string>|callable|string>
+     * @phpstan-var array<string, array<ParserCallableString>|ParserCallableString|ParserCallable>
      */
     public $plugins = [];
 

--- a/app/Views/discussions/posts/_create.php
+++ b/app/Views/discussions/posts/_create.php
@@ -37,6 +37,8 @@
                             'data-upload-size' => config('ImageUpload')->fileSize,
                             'data-upload-mime' => config('ImageUpload')->getMime(),
                             'data-upload-url' => config('ImageUpload')->uploadUrl,
+                            'data-csrf-name' => config('Security')->tokenName,
+                            'data-csrf-header' => config('Security')->headerName,
                         ]); ?>
                         <?php if ($validator->hasError('body')): ?>
                             <label class="label">

--- a/app/Views/discussions/posts/_edit.php
+++ b/app/Views/discussions/posts/_edit.php
@@ -34,6 +34,8 @@
                         'data-upload-size' => config('ImageUpload')->fileSize,
                         'data-upload-mime' => config('ImageUpload')->getMime(),
                         'data-upload-url' => config('ImageUpload')->uploadUrl,
+                        'data-csrf-name' => config('Security')->tokenName,
+                        'data-csrf-header' => config('Security')->headerName,
                     ]); ?>
                     <?php if ($validator->hasError('body')): ?>
                         <label class="label">

--- a/app/Views/discussions/threads/_edit.php
+++ b/app/Views/discussions/threads/_edit.php
@@ -73,6 +73,8 @@
                         'data-upload-size' => config('ImageUpload')->fileSize,
                         'data-upload-mime' => config('ImageUpload')->getMime(),
                         'data-upload-url' => config('ImageUpload')->uploadUrl,
+                        'data-csrf-name' => config('Security')->tokenName,
+                        'data-csrf-header' => config('Security')->headerName,
                     ]); ?>
                     <?php if ($validator->hasError('body')): ?>
                         <label class="label">

--- a/app/Views/discussions/threads/create.php
+++ b/app/Views/discussions/threads/create.php
@@ -73,6 +73,8 @@
                                 'data-upload-size' => config('ImageUpload')->fileSize,
                                 'data-upload-mime' => config('ImageUpload')->getMime(),
                                 'data-upload-url' => config('ImageUpload')->uploadUrl,
+                                'data-csrf-name' => config('Security')->tokenName,
+                                'data-csrf-header' => config('Security')->headerName,
                             ]); ?>
                             <?php if ($validator->hasError('body')): ?>
                                 <label class="label">

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "michalsn/codeigniter-htmx": "^1.2.2",
     "michalsn/codeigniter-queue": "dev-develop",
     "michalsn/codeigniter-signed-url": "^2.1",
-    "michalsn/codeigniter-tags": "dev-develop",
+    "michalsn/codeigniter-tags": "^1.0",
     "s9e/text-formatter": "^2.13"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a2e8eadab667740788d144b48f4c4818",
+    "content-hash": "baeadc8bf49dfb45eb9e91562f9cf16c",
     "packages": [
         {
             "name": "codeigniter4/framework",
-            "version": "v4.4.1",
+            "version": "v4.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/codeigniter4/framework.git",
-                "reference": "844616ef291ca07b726c1aaca552e16aadc3ceeb"
+                "reference": "c84d3223de9320d58a770601aa427e2c1ae845d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/codeigniter4/framework/zipball/844616ef291ca07b726c1aaca552e16aadc3ceeb",
-                "reference": "844616ef291ca07b726c1aaca552e16aadc3ceeb",
+                "url": "https://api.github.com/repos/codeigniter4/framework/zipball/c84d3223de9320d58a770601aa427e2c1ae845d9",
+                "reference": "c84d3223de9320d58a770601aa427e2c1ae845d9",
                 "shasum": ""
             },
             "require": {
@@ -78,7 +78,7 @@
                 "slack": "https://codeigniterchat.slack.com",
                 "source": "https://github.com/codeigniter4/CodeIgniter4"
             },
-            "time": "2023-09-05T00:46:08+00:00"
+            "time": "2023-10-19T21:36:24+00:00"
         },
         {
             "name": "codeigniter4/settings",
@@ -807,16 +807,16 @@
         },
         {
             "name": "michalsn/codeigniter-tags",
-            "version": "dev-develop",
+            "version": "v1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/michalsn/codeigniter-tags.git",
-                "reference": "ff128811876bd6c4511d28c98e5ed3f1650ec865"
+                "reference": "2b8e04767f53d3031465a5c2cb31007fa8681588"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/michalsn/codeigniter-tags/zipball/ff128811876bd6c4511d28c98e5ed3f1650ec865",
-                "reference": "ff128811876bd6c4511d28c98e5ed3f1650ec865",
+                "url": "https://api.github.com/repos/michalsn/codeigniter-tags/zipball/2b8e04767f53d3031465a5c2cb31007fa8681588",
+                "reference": "2b8e04767f53d3031465a5c2cb31007fa8681588",
                 "shasum": ""
             },
             "require": {
@@ -828,7 +828,6 @@
                 "codeigniter4/framework": "^4.1",
                 "rector/rector": "0.18.5"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "files": [
@@ -858,9 +857,9 @@
             ],
             "support": {
                 "issues": "https://github.com/michalsn/codeigniter-tags/issues",
-                "source": "https://github.com/michalsn/codeigniter-tags/tree/develop"
+                "source": "https://github.com/michalsn/codeigniter-tags/tree/v1.0.0"
             },
-            "time": "2023-10-05T18:07:17+00:00"
+            "time": "2023-10-19T18:03:36+00:00"
         },
         {
             "name": "myth/collection",
@@ -7123,7 +7122,7 @@
     "stability-flags": {
         "codeigniter4/shield": 10,
         "codeigniter4/tasks": 20,
-        "michalsn/codeigniter-tags": 20
+        "michalsn/codeigniter-queue": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/tests/Controllers/AccountControllerTest.php
+++ b/tests/Controllers/AccountControllerTest.php
@@ -49,11 +49,13 @@ final class AccountControllerTest extends TestCase
             'username' => 'testuser',
         ]);
         $user->addGroup('user');
-        $response = $this->actingAs($user)->post('account/notifications', [
-            'email_thread'     => 1,
-            'email_post'       => 0,
-            'email_post_reply' => 0,
-        ]);
+        $response = $this
+            ->withHeaders([csrf_header() => csrf_hash()])
+            ->actingAs($user)->post('account/notifications', [
+                'email_thread'     => 1,
+                'email_post'       => 0,
+                'email_post_reply' => 0,
+            ]);
 
         $response->assertOK();
         $response->assertSeeElement('h2');

--- a/tests/Controllers/ImageControllerTest.php
+++ b/tests/Controllers/ImageControllerTest.php
@@ -36,7 +36,9 @@ final class ImageControllerTest extends TestCase
      */
     public function testCanGuestUploadAnImage()
     {
-        $response = $this->post('images/upload');
+        $response = $this
+            ->withHeaders([csrf_header() => csrf_hash()])
+            ->post('images/upload');
 
         $response->assertStatus(401);
         $response->assertJSONExact(['error' => 'You are not allowed to upload images.']);
@@ -51,7 +53,9 @@ final class ImageControllerTest extends TestCase
             'username' => 'testuser',
         ]);
         $user->addGroup('user');
-        $response = $this->actingAs($user)->post('images/upload');
+        $response = $this
+            ->withHeaders([csrf_header() => csrf_hash()])
+            ->actingAs($user)->post('images/upload');
 
         $response->assertStatus(400);
         $response->assertJSONExact(['error' => 'image is not a valid uploaded file.']);
@@ -80,7 +84,9 @@ final class ImageControllerTest extends TestCase
             'username' => 'testuser',
         ]);
         $user->addGroup('user');
-        $response = $this->actingAs($user)->post('images/upload');
+        $response = $this
+            ->withHeaders([csrf_header() => csrf_hash()])
+            ->actingAs($user)->post('images/upload');
 
         $response->assertStatus(400);
         $response->assertJSONExact(['error' => 'image is not a valid uploaded file.']);

--- a/tests/Controllers/PostControllerTest.php
+++ b/tests/Controllers/PostControllerTest.php
@@ -52,11 +52,13 @@ final class PostControllerTest extends TestCase
         ]);
 
         $fileUrl  = base_url('uploads/' . $user->id . '/test_image1.jpg');
-        $response = $this->actingAs($user)->post('posts/1', [
-            'thread_id' => '1',
-            'reply_to'  => '',
-            'body'      => 'Sample body for post ![](' . $fileUrl . ')',
-        ]);
+        $response = $this
+            ->withHeaders([csrf_header() => csrf_hash()])
+            ->actingAs($user)->post('posts/1', [
+                'thread_id' => '1',
+                'reply_to'  => '',
+                'body'      => 'Sample body for post ![](' . $fileUrl . ')',
+            ]);
 
         $response->assertStatus(200);
         $response->seeElement('.post-meta');
@@ -87,7 +89,8 @@ final class PostControllerTest extends TestCase
     public function testCanGuestCreateAPost()
     {
         $response = $this->withHeaders([
-            'HX-Request' => 'true',
+            'HX-Request'  => 'true',
+            csrf_header() => csrf_hash(),
         ])->post('posts/1', [
             'thread_id' => '1',
             'reply_to'  => '',
@@ -127,7 +130,8 @@ final class PostControllerTest extends TestCase
         ]);
         $user->addGroup('user');
         $response = $this->actingAs($user)->withHeaders([
-            'HX-Request' => 'true',
+            'HX-Request'  => 'true',
+            csrf_header() => csrf_hash(),
         ])->withBody(http_build_query([
             'thread_id' => '1',
             'reply_to'  => '',
@@ -172,7 +176,7 @@ final class PostControllerTest extends TestCase
             'thread_id' => '1',
             'reply_to'  => '',
             'body'      => 'Sample updated post body ![](' . $fileUrl . ')',
-        ]))->put('posts/1/edit');
+        ]))->withHeaders([csrf_header() => csrf_hash()])->put('posts/1/edit');
 
         $response->assertOK();
         $response->assertSeeElement('.post-meta');

--- a/tests/Controllers/ThreadControllerTest.php
+++ b/tests/Controllers/ThreadControllerTest.php
@@ -52,11 +52,13 @@ final class ThreadControllerTest extends TestCase
         ]);
 
         $fileUrl  = base_url('uploads/' . $user->id . '/test_image1.jpg');
-        $response = $this->actingAs($user)->post('discussions/new', [
-            'title'       => 'A new thread',
-            'category_id' => 2,
-            'body'        => 'Sample body ![](' . $fileUrl . ')',
-        ]);
+        $response = $this
+            ->withHeaders([csrf_header() => csrf_hash()])
+            ->actingAs($user)->post('discussions/new', [
+                'title'       => 'A new thread',
+                'category_id' => 2,
+                'body'        => 'Sample body ![](' . $fileUrl . ')',
+            ]);
 
         $response->assertStatus(200);
         $response->assertHeader('hx-redirect', site_url(implode('/', [
@@ -77,12 +79,14 @@ final class ThreadControllerTest extends TestCase
             'username' => 'testuser',
         ]);
         $user->addGroup('user');
-        $response = $this->actingAs($user)->post('discussions/new', [
-            'title'       => 'A new thread',
-            'category_id' => 2,
-            'tags'        => 'tag1,tag2',
-            'body'        => 'Sample body',
-        ]);
+        $response = $this
+            ->withHeaders([csrf_header() => csrf_hash()])
+            ->actingAs($user)->post('discussions/new', [
+                'title'       => 'A new thread',
+                'category_id' => 2,
+                'tags'        => 'tag1,tag2',
+                'body'        => 'Sample body',
+            ]);
 
         $response->assertStatus(200);
         $response->assertHeader('hx-redirect', site_url(implode('/', [
@@ -116,7 +120,8 @@ final class ThreadControllerTest extends TestCase
     public function testCanGuestCreateADiscussion()
     {
         $response = $this->withHeaders([
-            'HX-Request' => 'true',
+            'HX-Request'  => 'true',
+            csrf_header() => csrf_hash(),
         ])->post('discussions/new', [
             'title'       => 'A new thread',
             'category_id' => 2,
@@ -156,7 +161,8 @@ final class ThreadControllerTest extends TestCase
         ]);
         $user->addGroup('user');
         $response = $this->actingAs($user)->withHeaders([
-            'HX-Request' => 'true',
+            'HX-Request'  => 'true',
+            csrf_header() => csrf_hash(),
         ])->withBody(http_build_query([
             'title'       => 'A updated thread',
             'category_id' => 2,
@@ -201,7 +207,7 @@ final class ThreadControllerTest extends TestCase
             'title'       => 'A updated thread',
             'category_id' => 2,
             'body'        => 'Sample updated body ![](' . $fileUrl . ')',
-        ]))->put('discussions/1/edit');
+        ]))->withHeaders([csrf_header() => csrf_hash()])->put('discussions/1/edit');
 
         $response->assertOK();
         $response->assertSee('A updated thread', 'h3');
@@ -221,7 +227,7 @@ final class ThreadControllerTest extends TestCase
             'category_id' => 2,
             'tags'        => 'tag1,tag2',
             'body'        => 'Sample updated body',
-        ]))->put('discussions/1/edit');
+        ]))->withHeaders([csrf_header() => csrf_hash()])->put('discussions/1/edit');
 
         $response->assertOK();
         $response->assertSee('A updated thread', 'h3');
@@ -243,7 +249,7 @@ final class ThreadControllerTest extends TestCase
             'category_id' => 2,
             'tags'        => 'tag1,tag2',
             'body'        => 'Sample updated body',
-        ]))->put('discussions/2/edit');
+        ]))->withHeaders([csrf_header() => csrf_hash()])->put('discussions/2/edit');
 
         $response->assertOK();
         $response->assertSee('A updated thread', 'h3');

--- a/themes/default/js/components/markdownEditor.js
+++ b/themes/default/js/components/markdownEditor.js
@@ -5,6 +5,9 @@ export function initEditor(elem) {
   const uploadSize = Number(elem.dataset.uploadSize * 1024 || 1024 * 1024 * 2);
   const uploadMime = (elem.dataset.uploadMime || 'image/png,image/jpeg').split(',');
   const uploadUrl = elem.dataset.uploadUrl || '/images/upload';
+  const csrfName = elem.dataset.csrfName || '';
+  const csrfToken = elem.closest('form').querySelector('input[name="' + csrfName + '"]').value || '';
+  const csrfHeader = elem.dataset.csrfHeader || '';
 
   const easyMDE = new EasyMDE({
     element: elem,
@@ -13,6 +16,9 @@ export function initEditor(elem) {
     imageMaxSize: uploadSize,
     imageAccept: uploadMime,
     imageUploadEndpoint: uploadUrl,
+    imageCSRFHeader: true,
+    imageCSRFName: csrfHeader,
+    imageCSRFToken: csrfToken,
   });
 
   easyMDE.codemirror.on("change", () => {


### PR DESCRIPTION
This PR enables the CSRF filter and upgrades CodeIgniter to version 4.4.2.

* v4.4.2 was required to enable CSRF in our case (ref: https://github.com/codeigniter4/CodeIgniter4/pull/7915)
* I also updated the readme to include links to the icons and markdown editor

resolved #103

