### PR TITLE
docs: add MySQL to "System Requirements"

### DIFF
--- a/_docs/start.md
+++ b/_docs/start.md
@@ -4,6 +4,7 @@
 
 -   PHP 8.1+
 -   Node 18.12.1+
+-   MySQL 8.0+
 
 ## Packages Used
 


### PR DESCRIPTION
Does not work with MySQL 5.7.
```
You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '(PARTITION BY reply_to ORDER BY created_at DESC) AS reply_rank FROM `posts` WHER' at line 2
in SYSTEMPATH/Database/BaseConnection.php on line 647.
 1 SYSTEMPATH/Database/BaseBuilder.php(1615): CodeIgniter\Database\BaseConnection->query('SELECT *
FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY reply_to ORDER BY created_at DESC) AS reply_rank FROM `posts` WHERE `reply_to` IN (1794,1795,1796,1797,1798)) `pr`
WHERE `pr`.`reply_rank` <= :pr.reply_rank:
ORDER BY `pr`.`reply_to` ASC, `pr`.`created_at` ASC', [...], false)
 2 APPPATH/Models/PostModel.php(108): CodeIgniter\Database\BaseBuilder->get()
 3 APPPATH/Models/PostModel.php(82): App\Models\PostModel->getReplies([...], 2)
 4 APPPATH/Models/PostModel.php(71): App\Models\PostModel->withReplies([...])
 5 APPPATH/Controllers/Discussions/DiscussionController.php(190): App\Models\PostModel->forThread(358, 10, null)
 6 SYSTEMPATH/CodeIgniter.php(942): App\Controllers\Discussions\DiscussionController->thread('esse-pariatur-id-illo-aperiam')
 7 SYSTEMPATH/CodeIgniter.php(502): CodeIgniter\CodeIgniter->runController(Object(App\Controllers\Discussions\DiscussionController))
 8 SYSTEMPATH/CodeIgniter.php(361): CodeIgniter\CodeIgniter->handleRequest(null, Object(Config\Cache), false)
 9 FCPATH/index.php(79): CodeIgniter\CodeIgniter->run()
10 SYSTEMPATH/Commands/Server/rewrite.php(47): require_once('/.../forum-example/public/index.php')
```
