### PR TITLE
Alerts update

### DIFF
--- a/_docs/alerts.md
+++ b/_docs/alerts.md
@@ -67,3 +67,9 @@ To change that we have to edit view file: `app/Views/_alerts/container`.
 
 By default, each alert is hidden after 5 seconds. We can change that by
 changing config variable: `Config\Forum::alertDisplayTime`.
+
+Display time of individual alert can be changed on demand via 3rd (optional) parameter: 
+
+```php
+alerts()->set('success', 'This message will last 10 seconds', 10);
+```

--- a/app/Config/Services.php
+++ b/app/Config/Services.php
@@ -36,6 +36,6 @@ class Services extends BaseService
             return static::getSharedInstance('alerts');
         }
 
-        return new Alerts(static::session());
+        return new Alerts(config(Forum::class), static::session());
     }
 }

--- a/app/Filters/AlertsFilter.php
+++ b/app/Filters/AlertsFilter.php
@@ -26,6 +26,8 @@ class AlertsFilter implements FilterInterface
      */
     public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
     {
+        helper('alerts');
+
         if ($response instanceof RedirectResponse) {
             alerts()->session();
 

--- a/app/Libraries/Alerts.php
+++ b/app/Libraries/Alerts.php
@@ -3,25 +3,29 @@
 namespace App\Libraries;
 
 use CodeIgniter\Session\Session;
+use Config\Forum;
 
 class Alerts
 {
     protected array $data = [];
 
-    public function __construct(protected Session $session)
+    public function __construct(protected Forum $config, protected Session $session)
     {
     }
 
     /**
      * Set alert type and message
      */
-    public function set(string $type, string $message): static
+    public function set(string $type, string $message, ?int $seconds = null): static
     {
         if (! isset($this->data[$type])) {
             $this->data[$type] = [];
         }
 
-        $this->data[$type][] = $message;
+        $this->data[$type][] = [
+            'message' => $message,
+            'seconds' => $seconds ?? $this->config->alertDisplayTime,
+        ];
 
         return $this;
     }

--- a/app/Views/_alerts/alerts.php
+++ b/app/Views/_alerts/alerts.php
@@ -4,9 +4,9 @@
              x-data="{ show: true }"
              x-show="show"
              x-transition
-             x-init="setTimeout(() => show = false, <?= config('Forum')->alertDisplayTime * 1000 ?>)"
+             x-init="setTimeout(() => show = false, <?= $message['seconds'] * 1000 ?>)"
         >
-            <span><?= esc($message); ?></span>
+            <span><?= esc($message['message']); ?></span>
         </div>
     <?php endforeach; ?>
 <?php endforeach; ?>

--- a/app/Views/_alerts/alerts.php
+++ b/app/Views/_alerts/alerts.php
@@ -1,12 +1,15 @@
 <?php foreach ($alerts as $type => $messages): ?>
     <?php foreach ($messages as $message): ?>
-        <div class="alert alert-<?= esc($type, 'attr'); ?>"
-             x-data="{ show: true }"
-             x-show="show"
-             x-transition
-             x-init="setTimeout(() => show = false, <?= $message['seconds'] * 1000 ?>)"
-        >
-            <span><?= esc($message['message']); ?></span>
+        <div class="alert-component" x-data="alerts(<?= $message['seconds']; ?>)">
+            <progress class="progress progress-<?= esc($type, 'attr'); ?>"
+                      x-model="progress" max="100"
+            ></progress>
+            <div class="alert alert-<?= esc($type, 'attr'); ?>"
+                 @mouseover="pauseCountdown"
+                 @mouseleave="resumeCountdown"
+            >
+                <span><?= esc($message['message']); ?></span>
+            </div>
         </div>
     <?php endforeach; ?>
 <?php endforeach; ?>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,14 @@ module.exports = {
     "./app/Views/**/*.{html,php,js,ts,jsx,tsx}",
     "./app/Views/**/**/*.{html,php,js,ts,jsx,tsx}",
   ],
+  safelist: [
+    'alert-success',
+    'alert-error',
+    'alert-info',
+    'progress-success',
+    'progress-error',
+    'progress-info',
+  ],
   theme: {
     extend: {},
   },

--- a/tests/Libraries/AlertsTest.php
+++ b/tests/Libraries/AlertsTest.php
@@ -2,6 +2,7 @@
 
 use App\Libraries\Alerts;
 use CodeIgniter\Test\CIUnitTestCase;
+use Config\Forum;
 use Config\Services;
 
 /**
@@ -11,23 +12,26 @@ final class AlertsTest extends CIUnitTestCase
 {
     public function testInstance()
     {
-        $alerts = new Alerts(Services::session());
+        $alerts = new Alerts(config(Forum::class), Services::session());
         $this->assertInstanceOf(Alerts::class, $alerts);
     }
 
     public function testSetGetClear()
     {
-        $alerts = new Alerts(Services::session());
+        $alerts = new Alerts(config(Forum::class), Services::session());
         $alerts
             ->set('success', 'message1')
             ->set('error', 'message2');
 
-        $this->assertSame(['message1'], $alerts->get('success'));
-        $this->assertSame(['success' => ['message1'], 'error' => ['message2']], $alerts->get());
+        $this->assertSame([['message' => 'message1', 'seconds' => 5]], $alerts->get('success'));
+        $this->assertSame([
+            'success' => [['message' => 'message1', 'seconds' => 5]],
+            'error' => [['message' => 'message2', 'seconds' => 5]],
+        ], $alerts->get());
 
         $alerts->clear('error');
         $this->assertSame([], $alerts->get('error'));
-        $this->assertSame(['success' => ['message1']], $alerts->get());
+        $this->assertSame(['success' => [['message' => 'message1', 'seconds' => 5]]], $alerts->get());
 
         $alerts->clear();
         $this->assertSame([], $alerts->get());
@@ -35,7 +39,7 @@ final class AlertsTest extends CIUnitTestCase
 
     public function testInline()
     {
-        $alerts = new Alerts(Services::session());
+        $alerts = new Alerts(config(Forum::class), Services::session());
         $alerts->set('success', 'message1');
         $this->assertStringContainsString('hx-swap-oob="beforeend:#alerts-container"', $alerts->inline());
         $this->assertStringContainsString('alert-success', $alerts->inline());
@@ -44,7 +48,7 @@ final class AlertsTest extends CIUnitTestCase
 
     public function testInlineEmpty()
     {
-        $alerts = new Alerts(Services::session());
+        $alerts = new Alerts(config(Forum::class), Services::session());
         $this->assertSame('', $alerts->inline());
     }
 
@@ -58,7 +62,7 @@ final class AlertsTest extends CIUnitTestCase
 
     public function testContainer()
     {
-        $alerts = new Alerts(Services::session());
+        $alerts = new Alerts(config(Forum::class), Services::session());
         $this->assertStringContainsString('id="alerts-container"', $alerts->container());
     }
 }

--- a/tests/Libraries/AlertsTest.php
+++ b/tests/Libraries/AlertsTest.php
@@ -26,7 +26,7 @@ final class AlertsTest extends CIUnitTestCase
         $this->assertSame([['message' => 'message1', 'seconds' => 5]], $alerts->get('success'));
         $this->assertSame([
             'success' => [['message' => 'message1', 'seconds' => 5]],
-            'error' => [['message' => 'message2', 'seconds' => 5]],
+            'error'   => [['message' => 'message2', 'seconds' => 5]],
         ], $alerts->get());
 
         $alerts->clear('error');

--- a/themes/default/js/app.js
+++ b/themes/default/js/app.js
@@ -4,6 +4,9 @@ import Alpine from 'alpinejs';
 import "./events.js";
 import { initEditor } from "./components/markdownEditor.js";
 import { initTags } from "./components/tags.js";
+import alerts from "./components/alerts.js";
+
+Alpine.data('alerts', alerts);
 
 window.Alpine = Alpine;
 

--- a/themes/default/js/components/alerts.js
+++ b/themes/default/js/components/alerts.js
@@ -1,0 +1,33 @@
+export default (displayTime = 5) => ({
+  timer: null,
+  countdown: 0,
+  progress: 0,
+  max: displayTime,
+  stepInterval: 50,
+  init() {
+    this.startCountDown();
+  },
+  startCountDown() {
+    const totalSteps = (this.max / (this.stepInterval / 1000));
+    const stepWidth = 100 / totalSteps;
+
+    this.timer = setInterval(() => {
+      if (this.countdown < this.max) {
+        this.countdown += this.stepInterval / 1000
+        this.progress += stepWidth;
+      } else {
+        this.destroy();
+      }
+    }, this.stepInterval);
+  },
+  pauseCountdown() {
+    clearInterval(this.timer);
+  },
+  resumeCountdown() {
+    this.startCountDown();
+  },
+  destroy() {
+    clearInterval(this.timer);
+    this.$el.closest('.alert-component').remove();
+  },
+})

--- a/themes/default/js/htmx.js
+++ b/themes/default/js/htmx.js
@@ -1,2 +1,5 @@
 import htmx from 'htmx.org';
+
+htmx.config.selfRequestsOnly = true;
+
 window.htmx = htmx;


### PR DESCRIPTION
This PR addresses requests mentioned in the [#118](https://github.com/lonnieezell/forum-example/pull/118#discussion_r1377244694)

* configurable display time for alert via 3rd (optional) parameter 
```php
alerts()->set('success', 'alert message', 10);
```
* pause alert's display time on hover 
* show a progress bar for every alert (this doesn't look very good right now because I use a standard progress component, but it can be fixed in the future)