### PR TITLE
Set default sort for discussion list

### DIFF
--- a/app/Controllers/Discussions/DiscussionController.php
+++ b/app/Controllers/Discussions/DiscussionController.php
@@ -28,7 +28,7 @@ class DiscussionController extends BaseController
     {
         $table = [
             'perPage' => $this->request->getGet('perPage') ?? 20,
-            'search'  => $this->request->getGet('search') ?? [],
+            'search'  => $this->request->getGet('search') ?? ['type' => 'recent-posts'],
         ];
 
         $rules = [
@@ -67,7 +67,7 @@ class DiscussionController extends BaseController
     {
         $table = [
             'perPage' => $this->request->getGet('perPage') ?? 20,
-            'search'  => $this->request->getGet('search') ?? [],
+            'search'  => $this->request->getGet('search') ?? ['type' => 'recent-posts'],
         ];
         $table['search']['category'] = $slug;
 
@@ -109,7 +109,7 @@ class DiscussionController extends BaseController
     {
         $table = [
             'perPage' => $this->request->getGet('perPage') ?? 20,
-            'search'  => $this->request->getGet('search') ?? [],
+            'search'  => $this->request->getGet('search') ?? ['type' => 'recent-posts'],
         ];
 
         $table['search']['tag'] = $tagSlug;


### PR DESCRIPTION
By default, sorting is not defined for HTML, but the model uses **recent-posts**.
The initial type is incorrect **recent-threads**