### PR TITLE
Disable access to private categories

### DIFF
--- a/app/Controllers/Discussions/DiscussionController.php
+++ b/app/Controllers/Discussions/DiscussionController.php
@@ -62,9 +62,17 @@ class DiscussionController extends BaseController
 
     /**
      * Display a standard forum-style list of discussions.
+     *
+     * @throws PageNotFoundException
      */
     public function category(string $slug): string
     {
+        $activeCategory = model(CategoryModel::class)->active()->public()->findBySlug($slug);
+
+        if (! $activeCategory) {
+            throw PageNotFoundException::forPageNotFound();
+        }
+
         $table = [
             'perPage' => $this->request->getGet('perPage') ?? 20,
             'search'  => $this->request->getGet('search') ?? ['type' => 'recent-posts'],
@@ -94,7 +102,7 @@ class DiscussionController extends BaseController
                 'pager' => $threadModel->pager,
             ],
             'searchUrl'      => route_to('category', $slug),
-            'activeCategory' => model(CategoryModel::class)->findBySlug($slug),
+            'activeCategory' => $activeCategory,
         ];
 
         $data['table'] = [...$table, ...$data['table']];

--- a/app/Controllers/Discussions/ThreadController.php
+++ b/app/Controllers/Discussions/ThreadController.php
@@ -46,7 +46,7 @@ class ThreadController extends BaseController
 
         helper('form');
 
-        $categoryDropdown = model(CategoryModel::class)->findAllNestedDropdown();
+        $categoryDropdown = model(CategoryModel::class)->active()->public()->findAllNestedDropdown();
 
         if ($this->request->is('post')) {
             $validCategoryIds = array_reduce($categoryDropdown, static fn ($keys, $innerArray) => array_merge($keys, array_keys($innerArray)), []);
@@ -100,7 +100,7 @@ class ThreadController extends BaseController
 
         helper('form');
 
-        $categoryDropdown = model(CategoryModel::class)->findAllNestedDropdown();
+        $categoryDropdown = model(CategoryModel::class)->active()->public()->findAllNestedDropdown();
 
         if ($this->request->is('put')) {
             $validCategoryIds = array_reduce($categoryDropdown, static fn ($keys, $innerArray) => array_merge($keys, array_keys($innerArray)), []);


### PR DESCRIPTION
Now it is acceptable to view discussions, create/edit for a thread (dropdown HTML) of a private/inactive category. 