### PR TITLE
Load htmx.js

### DIFF
--- a/themes/default/js/app.js
+++ b/themes/default/js/app.js
@@ -1,4 +1,4 @@
-import "htmx.org/dist/ext/preload.js";
+import "./htmx.js";
 import "htmx.org/dist/ext/loading-states";
 import Alpine from "alpinejs";
 import "./events.js";

--- a/themes/default/js/htmx.js
+++ b/themes/default/js/htmx.js
@@ -1,4 +1,4 @@
-import htmx from 'htmx.org';
+import htmx from "htmx.org";
 
 htmx.config.selfRequestsOnly = true;
 

--- a/themes/default/js/htmx.js
+++ b/themes/default/js/htmx.js
@@ -1,5 +1,3 @@
-import htmx from "htmx.org";
-
 htmx.config.selfRequestsOnly = true;
 
 window.htmx = htmx;


### PR DESCRIPTION
This PR fixes an error:
```
Uncaught ReferenceError: htmx is not defined
```
when trying to sort discussions by type (dropdown).


Also `htmx.org/dist/ext/preload.js` seemed not to be used in the code, so I removed it.