### PR TITLE
feat: send daily moderation summary email

### DIFF
--- a/app/Commands/DailyModerationSummary.php
+++ b/app/Commands/DailyModerationSummary.php
@@ -43,8 +43,6 @@ class DailyModerationSummary extends BaseCommand
 
     /**
      * Actually execute a command.
-     *
-     * @param array $params
      */
     public function run(array $params)
     {
@@ -52,6 +50,7 @@ class DailyModerationSummary extends BaseCommand
 
         if ($users === []) {
             CLI::write('No users to notify');
+
             return EXIT_SUCCESS;
         }
 
@@ -76,6 +75,7 @@ class DailyModerationSummary extends BaseCommand
         }
 
         CLI::write(sprintf('%s emails has been sent', count($users)), 'green');
+
         return EXIT_SUCCESS;
     }
 

--- a/app/Commands/DailyModerationSummary.php
+++ b/app/Commands/DailyModerationSummary.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace App\Commands;
+
+use App\Models\ModerationLogModel;
+use App\Models\ModerationReportModel;
+use App\Models\NotificationSettingModel;
+use App\Models\UserModel;
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\CLI;
+use CodeIgniter\I18n\Time;
+use Exception;
+
+class DailyModerationSummary extends BaseCommand
+{
+    /**
+     * The Command's Group
+     *
+     * @var string
+     */
+    protected $group = 'Forum';
+
+    /**
+     * The Command's Name
+     *
+     * @var string
+     */
+    protected $name = 'moderation:summary';
+
+    /**
+     * The Command's Description
+     *
+     * @var string
+     */
+    protected $description = 'Send a daily moderation summary with stats';
+
+    /**
+     * The Command's Usage
+     *
+     * @var string
+     */
+    protected $usage = 'moderation:summary';
+
+    /**
+     * Actually execute a command.
+     *
+     * @param array $params
+     */
+    public function run(array $params)
+    {
+        $users = model(NotificationSettingModel::class)->where('moderation_daily_summary', 1)->findAll();
+
+        if ($users === []) {
+            CLI::write('No users to notify');
+            return EXIT_SUCCESS;
+        }
+
+        // Prepare summary
+        $summary = $this->summary();
+
+        // Prepare users
+        $users = array_column($users, 'user_id');
+        $users = model(UserModel::class)->whereIn('id', $users)->findAll();
+
+        $queue = service('queue');
+
+        foreach ($users as $user) {
+            $queue->push('emails', 'email-simple-message', [
+                'to'      => $user->email,
+                'subject' => 'Daily moderation summary stats',
+                'message' => view('_emails/daily_moderation_summary', [
+                    'user'    => $user,
+                    'summary' => $summary,
+                ]),
+            ]);
+        }
+
+        CLI::write(sprintf('%s emails has been sent', count($users)), 'green');
+        return EXIT_SUCCESS;
+    }
+
+    /**
+     * Prepare summary.
+     *
+     * @throws Exception
+     */
+    protected function summary(): array
+    {
+        return [
+            'waiting' => $this->waitingInQueue(),
+            'thread'  => $this->moderatedToday('thread'),
+            'post'    => $this->moderatedToday('post'),
+        ];
+    }
+
+    /**
+     * Waiting posts and threads for moderation.
+     */
+    protected function waitingInQueue(): array
+    {
+        $waiting = model(ModerationReportModel::class)
+            ->builder()
+            ->select('COUNT(*) AS count, resource_type')
+            ->groupBy('resource_type')
+            ->get()
+            ->getResultArray();
+
+        return array_column($waiting, 'count', 'resource_type');
+    }
+
+    /**
+     * Moderated items by action status.
+     *
+     * @throws Exception
+     */
+    protected function moderatedToday(string $resourceType): array
+    {
+        $moderated = model(ModerationLogModel::class)
+            ->builder()
+            ->select('COUNT(*) AS count, status')
+            ->where('DATE(created_at)', Time::now()->format('Y-m-d'))
+            ->where('resource_type', $resourceType)
+            ->groupBy('status')
+            ->get()
+            ->getResultArray();
+
+        return array_column($moderated, 'count', 'status');
+    }
+}

--- a/app/Config/Tasks.php
+++ b/app/Config/Tasks.php
@@ -43,6 +43,9 @@ class Tasks extends BaseConfig
         // cleanup unused images
         $schedule->command('cleanup:images 3')->hourly()->named('cleanup-images');
 
+        // daily moderation summary
+        $schedule->command('moderation:summary')->daily('11:50 pm')->named('daily-moderation-summary');
+
         // always set at the last position, so that other tasks can be executed first
         $schedule->command('queue:work emails -max 20 --stop-when-empty')->everyMinute()->named('queue-emails');
     }

--- a/app/Controllers/Account/AccountController.php
+++ b/app/Controllers/Account/AccountController.php
@@ -66,11 +66,17 @@ class AccountController extends BaseController
     {
         helper('form');
 
-        if ($this->request->is('post') && $this->validate([
+        $rules = [
             'email_thread'     => ['required', 'in_list[0,1]'],
             'email_post'       => ['required', 'in_list[0,1]'],
             'email_post_reply' => ['required', 'in_list[0,1]'],
-        ])) {
+        ];
+
+        if ($this->policy->can('moderation.logs')) {
+            $rules['moderation_daily_summary'] = ['required', 'in_list[0,1]'];
+        }
+
+        if ($this->request->is('post') && $this->validate($rules)) {
             $settings          = new NotificationSetting($this->validator->getValidated());
             $settings->user_id = user_id();
 

--- a/app/Database/Migrations/2023-10-03-122331_AddNotificationSettingsTable.php
+++ b/app/Database/Migrations/2023-10-03-122331_AddNotificationSettingsTable.php
@@ -9,12 +9,13 @@ class AddNotificationSettingsTable extends Migration
     public function up()
     {
         $this->forge->addField([
-            'user_id'          => ['type' => 'int', 'constraint' => 11, 'unsigned' => true],
-            'email_thread'     => ['type' => 'tinyint', 'constraint' => 1, 'unsigned' => true, 'null' => false, 'default' => 0],
-            'email_post'       => ['type' => 'tinyint', 'constraint' => 1, 'unsigned' => true, 'null' => false, 'default' => 0],
-            'email_post_reply' => ['type' => 'tinyint', 'constraint' => 1, 'unsigned' => true, 'null' => false, 'default' => 0],
-            'created_at'       => ['type' => 'datetime', 'null' => false],
-            'updated_at'       => ['type' => 'datetime', 'null' => false],
+            'user_id'                  => ['type' => 'int', 'constraint' => 11, 'unsigned' => true],
+            'email_thread'             => ['type' => 'tinyint', 'constraint' => 1, 'unsigned' => true, 'null' => false, 'default' => 0],
+            'email_post'               => ['type' => 'tinyint', 'constraint' => 1, 'unsigned' => true, 'null' => false, 'default' => 0],
+            'email_post_reply'         => ['type' => 'tinyint', 'constraint' => 1, 'unsigned' => true, 'null' => false, 'default' => 0],
+            'moderation_daily_summary' => ['type' => 'tinyint', 'constraint' => 1, 'unsigned' => true, 'null' => false, 'default' => 0],
+            'created_at'               => ['type' => 'datetime', 'null' => false],
+            'updated_at'               => ['type' => 'datetime', 'null' => false],
         ]);
         $this->forge->addForeignKey('user_id', 'users', 'id', '', 'cascade');
         $this->forge->addUniqueKey('user_id');

--- a/app/Models/NotificationSettingModel.php
+++ b/app/Models/NotificationSettingModel.php
@@ -13,7 +13,7 @@ class NotificationSettingModel extends Model
     protected $returnType       = NotificationSetting::class;
     protected $useSoftDeletes   = false;
     protected $protectFields    = true;
-    protected $allowedFields    = ['user_id', 'email_thread', 'email_post', 'email_post_reply'];
+    protected $allowedFields    = ['user_id', 'email_thread', 'email_post', 'email_post_reply', 'moderation_daily_summary'];
 
     // Dates
     protected $useTimestamps = true;

--- a/app/Views/_emails/daily_moderation_summary.php
+++ b/app/Views/_emails/daily_moderation_summary.php
@@ -1,0 +1,48 @@
+Hi <?= esc($user->username) ?>,
+
+<br><br>
+
+This is a daily moderation summary.
+
+<br><br>
+
+<table>
+    <tr>
+        <th scope="row" style="text-align: right;">Threads in the moderation queue:</th>
+        <td><?= $summary['waiting']['thread'] ?? 0; ?></td>
+    </tr>
+    <tr>
+        <th scope="row" style="text-align: right;">Posts in the moderation queue:</th>
+        <td><?= $summary['waiting']['post'] ?? 0; ?></td>
+    </tr>
+
+    <tr>
+        <th scope="row" style="text-align: right;">Threads approved today:</th>
+        <td><?= $summary['thread']['approved'] ?? 0; ?></td>
+    </tr>
+    <tr>
+        <th scope="row" style="text-align: right;">Threads denied today:</th>
+        <td><?= $summary['thread']['denied'] ?? 0; ?></td>
+    </tr>
+
+    <tr>
+        <th scope="row" style="text-align: right;">Posts approved today:</th>
+        <td><?= $summary['post']['approved'] ?? 0; ?></td>
+    </tr>
+    <tr>
+        <th scope="row" style="text-align: right;">Posts denied today:</th>
+        <td><?= $summary['post']['denied'] ?? 0; ?></td>
+    </tr>
+</table>
+
+<br><br>
+
+Thank you for making our community better and safer place!
+
+<br><br>
+
+<small>
+    —<br>
+    You are receiving this because you are subscribed to this type of notification.<br>
+    This behavior can be changed permanently in your <a href="<?= url_to('account-notifications') ?>">account settings</a>
+</small>

--- a/app/Views/account/_notifications.php
+++ b/app/Views/account/_notifications.php
@@ -46,6 +46,23 @@
         </div>
     </div>
 
+    <?php if (service('policy')->can('moderation.logs')): ?>
+        <h6 class="border-solid border-b-2 mt-6">Moderation</h6>
+        <div class="form-control">
+            <label class="label cursor-pointer flex">
+                <input type="hidden" name="moderation_daily_summary" value="0">
+                <input type="checkbox" name="moderation_daily_summary" value="1" <?= set_checkbox('moderation_daily_summary', '1', $notification->moderation_daily_summary) ?>
+                       class="toggle toggle-primary">
+                <span class="label-text ml-2 flex-auto">Send a daily summary with a moderation stats</span>
+            </label>
+            <?php if ($validator->hasError('moderation_daily_summary')): ?>
+                <label class="label">
+                    <span class="label-text-alt text-red-600"><?= $validator->getError('moderation_daily_summary'); ?></span>
+                </label>
+            <?php endif; ?>
+        </div>
+    <?php endif; ?>
+
     <div class="flex justify-center mt-6">
         <div class="btn-group btn-group-horizontal w-full">
             <button type="submit" class="btn btn-primary w-full" data-loading-disable>

--- a/tests/Controllers/AccountControllerTest.php
+++ b/tests/Controllers/AccountControllerTest.php
@@ -54,19 +54,21 @@ final class AccountControllerTest extends TestCase
         $response = $this
             ->withHeaders([csrf_header() => csrf_hash()])
             ->actingAs($user)->post('account/notifications', [
-                'email_thread'     => 1,
-                'email_post'       => 0,
-                'email_post_reply' => 0,
+                'email_thread'             => 1,
+                'email_post'               => 0,
+                'email_post_reply'         => 0,
+                'moderation_daily_summary' => 0,
             ]);
 
         $response->assertOK();
         $response->assertSeeElement('form');
 
         $this->seeInDatabase('notification_settings', [
-            'user_id'          => $user->id,
-            'email_thread'     => 1,
-            'email_post'       => 0,
-            'email_post_reply' => 0,
+            'user_id'                  => $user->id,
+            'email_thread'             => 1,
+            'email_post'               => 0,
+            'email_post_reply'         => 0,
+            'moderation_daily_summary' => 0,
         ]);
     }
 


### PR DESCRIPTION
This PR adds an option to send daily moderation summary emails. Available only for users with moderation permissions.

We can opt in or out of daily email messages via notification settings.

Fixes #144