### PR TITLE
feat: Cleanup up the main app navigation

### DIFF
--- a/app/Controllers/BaseController.php
+++ b/app/Controllers/BaseController.php
@@ -68,7 +68,7 @@ abstract class BaseController extends Controller
      */
     public function initController(RequestInterface $request, ResponseInterface $response, LoggerInterface $logger)
     {
-        $this->helpers = [...$this->helpers, 'setting', 'alerts'];
+        $this->helpers = [...$this->helpers, 'setting', 'alerts', 'cookie'];
 
         // Do Not Edit This Line
         parent::initController($request, $response, $logger);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,7 +24,7 @@ module.exports = {
       {
         light: {
           ...require("daisyui/src/theming/themes")["light"],
-          primary: "#ff6e42",
+          primary: "#DD4815",
           "primary-content": "#fff",
           "base-content": "#000000de",
           "base-100": "rgb(249, 250, 251)",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,20 +21,20 @@ module.exports = {
   },
   daisyui: {
     themes: [
-      "dark",
-      "light",
       {
-        my_dark: {
-          primary: "#6a290d",
-          "primary-content": "#fff",
-          "base-content": "rgb(155, 156, 163)",
-          "base-100": "rgb(30, 33, 41)",
-        },
-        my_light: {
+        light: {
+          ...require("daisyui/src/theming/themes")["light"],
           primary: "#ff6e42",
           "primary-content": "#fff",
           "base-content": "#000000de",
           "base-100": "rgb(249, 250, 251)",
+        },
+        dark: {
+          ...require("daisyui/src/theming/themes")["dark"],
+          primary: "#6a290d",
+          "primary-content": "#fff",
+          "base-content": "rgb(155, 156, 163)",
+          "base-100": "rgb(30, 33, 41)",
         },
       },
     ],

--- a/themes/default/_app_nav.php
+++ b/themes/default/_app_nav.php
@@ -8,15 +8,6 @@
                 </label>
                 <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-200 rounded-box w-52">
                     <li>
-                        <a href="#" data-theme-toggle>
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
-                            </svg>
-
-                            <span class="block text-centered sm:inline sm:text-left">Dark Theme</span>
-                        </a>
-                    </li>
-                    <li>
                         <a href="<?= site_url('discussions') ?>"
                             <?= url_is('discussions') ? 'class="active"' : '' ?>>
                             Discussions
@@ -34,36 +25,22 @@
                             Help
                         </a>
                     </li>
-                    <?php if ($modThread = service('policy')->can('moderation.threads') || service('policy')->can('moderation.posts')): ?>
-                        <li>
-                            <a href="<?= $modThread ? url_to('moderate-threads') : url_to('moderate-posts') ?>"
-                                <?= url_is('moderation') ? 'class="active"' : '' ?>>
-                                Moderate
-                            </a>
-                        </li>
-                    <?php endif; ?>
                     <?php if (! auth()->loggedIn()): ?>
                         <li><a href="<?= route_to('register') ?>" hx-boost="false">Sign Up</a></li>
                         <li><a href="<?= route_to('login') ?>" hx-boost="false">Sign In</a></li>
                     <?php endif ?>
 
                     <?php if (auth()->loggedIn()): ?>
-                        <li>
-                            <a class="w-full" href="<?= site_url('account') ?>">
-                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M17.982 18.725A7.488 7.488 0 0012 15.75a7.488 7.488 0 00-5.982 2.975m11.963 0a9 9 0 10-11.963 0m11.963 0A8.966 8.966 0 0112 21a8.966 8.966 0 01-5.982-2.275M15 9.75a3 3 0 11-6 0 3 3 0 016 0z" />
-                                </svg>
-                                Account
-                            </a>
-                            <ul class="menu">
-                                <?= view('account/_nav') ?>
-                            </ul>
-                        </li>
-                        <li>
+                        <?php if ($modThread = service('policy')->can('moderation.threads') || service('policy')->can('moderation.posts')): ?>
+                            <li>
+                                <a href="<?= $modThread ? url_to('moderate-threads') : url_to('moderate-posts') ?>"
+                                    <?= url_is('moderation') ? 'class="active"' : '' ?>>
+                                    Moderate
+                                </a>
+                            </li>
+                        <?php endif; ?>
+                        <li class="border-t border-base-content pt-2 mt-2">
                             <a class="w-full" href="<?= route_to('logout') ?>" hx-boost="false">
-                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15M12 9l-3 3m0 0l3 3m-3-3h12.75" />
-                                </svg>
                                 Logout
                             </a>
                         </li>
@@ -101,63 +78,52 @@
                             Help
                         </a>
                     </li>
-                    <?php if ($modThread = service('policy')->can('moderation.threads') || service('policy')->can('moderation.posts')): ?>
-                        <li>
-                            <a href="<?= $modThread ? url_to('moderate-threads') : url_to('moderate-posts') ?>"
-                                <?= url_is('moderation') ? 'class="active"' : '' ?>>
-                                Moderate
-                            </a>
-                        </li>
-                    <?php endif; ?>
-                </ul>
-            </div>
-            <div class="flex-none px-4">
-                <div class="form-control">
-                    <input type="text" placeholder="Search..." class="input input-bordered w-24 md:w-auto" />
-                </div>
-            </div>
-            <div class="flex-none">
-                <ul class="menu menu-horizontal px-1 gap-4">
+                    <!-- Auth -->
                     <?php if (! auth()->loggedIn()): ?>
                         <li><a href="<?= route_to('register') ?>" hx-boost="false">Sign Up</a></li>
                         <li><a href="<?= route_to('login') ?>" hx-boost="false">Sign In</a></li>
                     <?php endif ?>
                 </ul>
             </div>
-            <?php if (auth()->loggedIn()): ?>
-                <div class="dropdown dropdown-end">
-                    <label tabindex="0" class="btn btn-ghost btn-circle avatar">
-                            <?= auth()->user()->renderAvatar(40) ?>
-                    </label>
-                    <ul tabindex="0" class="mt-3 z-[1] p-2 shadow menu menu-sm dropdown-content bg-base-200 rounded-box w-52">
-                        <li>
-                            <a href="#" data-theme-toggle>
-                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
-                                </svg>
-
-                                <span class="block text-centered sm:inline sm:text-left">Dark Theme</span>
-                            </a>
-                        </li>
-                        <li>
-                            <a class="w-full" href="<?= site_url('account') ?>">
-                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M17.982 18.725A7.488 7.488 0 0012 15.75a7.488 7.488 0 00-5.982 2.975m11.963 0a9 9 0 10-11.963 0m11.963 0A8.966 8.966 0 0112 21a8.966 8.966 0 01-5.982-2.275M15 9.75a3 3 0 11-6 0 3 3 0 016 0z" />
-                                </svg>
-                                Account
-                            </a>
-                        </li>
-                        <li>
-                            <a class="w-full" href="<?= route_to('logout') ?>" hx-boost="false">
-                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15M12 9l-3 3m0 0l3 3m-3-3h12.75" />
-                                </svg>
-                                Logout
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-            <?php endif ?>
         </div>
+        <!-- Theme Toggle -->
+        <label class="swap swap-rotate ml-2">
+            <input type="checkbox" class="theme-controller hover:text-white" value="light"
+                <?= get_cookie('theme') === 'light' ? 'checked' : '' ?> />
+
+            <!-- sun icon -->
+            <svg class="swap-on fill-current w-6 h-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5.64,17l-.71.71a1,1,0,0,0,0,1.41,1,1,0,0,0,1.41,0l.71-.71A1,1,0,0,0,5.64,17ZM5,12a1,1,0,0,0-1-1H3a1,1,0,0,0,0,2H4A1,1,0,0,0,5,12Zm7-7a1,1,0,0,0,1-1V3a1,1,0,0,0-2,0V4A1,1,0,0,0,12,5ZM5.64,7.05a1,1,0,0,0,.7.29,1,1,0,0,0,.71-.29,1,1,0,0,0,0-1.41l-.71-.71A1,1,0,0,0,4.93,6.34Zm12,.29a1,1,0,0,0,.7-.29l.71-.71a1,1,0,1,0-1.41-1.41L17,5.64a1,1,0,0,0,0,1.41A1,1,0,0,0,17.66,7.34ZM21,11H20a1,1,0,0,0,0,2h1a1,1,0,0,0,0-2Zm-9,8a1,1,0,0,0-1,1v1a1,1,0,0,0,2,0V20A1,1,0,0,0,12,19ZM18.36,17A1,1,0,0,0,17,18.36l.71.71a1,1,0,0,0,1.41,0,1,1,0,0,0,0-1.41ZM12,6.5A5.5,5.5,0,1,0,17.5,12,5.51,5.51,0,0,0,12,6.5Zm0,9A3.5,3.5,0,1,1,15.5,12,3.5,3.5,0,0,1,12,15.5Z"/></svg>
+
+            <!-- moon icon -->
+            <svg class="swap-off fill-current w-6 h-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M21.64,13a1,1,0,0,0-1.05-.14,8.05,8.05,0,0,1-3.37.73A8.15,8.15,0,0,1,9.08,5.49a8.59,8.59,0,0,1,.25-2A1,1,0,0,0,8,2.36,10.14,10.14,0,1,0,22,14.05,1,1,0,0,0,21.64,13Zm-9.5,6.69A8.14,8.14,0,0,1,7.08,5.22v.27A10.15,10.15,0,0,0,17.22,15.63a9.79,9.79,0,0,0,2.1-.22A8.11,8.11,0,0,1,12.14,19.73Z"/></svg>
+
+        </label>
+        <?php if (auth()->loggedIn()): ?>
+            <div class="dropdown dropdown-end ml-4">
+                <label tabindex="0" class="btn btn-ghost btn-circle">
+                    <?= auth()->user()->renderAvatar(40) ?>
+                </label>
+                <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 bg-primary shadow rounded-box rounded-lg w-36">
+                    <?php if ($modThread = service('policy')->can('moderation.threads') || service('policy')->can('moderation.posts')): ?>
+                        <li>
+                            <a href="<?= $modThread ? url_to('moderate-threads') : url_to('moderate-posts') ?>">
+                                Moderate
+                            </a>
+                        </li>
+                    <?php endif; ?>
+                    <li>
+                        <a href="<?= url_to('account') ?>">
+                            Account
+                        </a>
+                    </li>
+                    <li class="separator"></li>
+                    <li>
+                        <a href="<?= url_to('logout') ?>" hx-boost="false">
+                            Logout
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        <?php endif ?>
     </div>
 </div>

--- a/themes/default/css/app.scss
+++ b/themes/default/css/app.scss
@@ -11,6 +11,20 @@ body {
     font-family: Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
 }
 
+.dropdown ul li {
+    @apply hover:bg-white/20 hover:text-primary-content;
+}
+.dropdown ul li.separator {
+    @apply border-t border-base-200;
+}
+.navbar .menu li a {
+    @apply hover:bg-white/20 hover:text-primary-content;
+
+    &.active {
+        @apply bg-white/20 text-primary-content;
+    }
+}
+
 form select.select {
     height: 3rem;
     padding-left: 1rem;

--- a/themes/default/css/app.scss
+++ b/themes/default/css/app.scss
@@ -18,11 +18,12 @@ body {
     @apply border-t border-base-200;
 }
 .navbar .menu li a {
-    @apply hover:bg-white/20 hover:text-primary-content;
+    @apply text-orange-50 hover:bg-white/20 hover:text-primary-content;
+}
 
-    &.active {
-        @apply bg-white/20 text-primary-content;
-    }
+// Override active nav colors
+.menu li > *:not(ul):not(.menu-title):not(details):active, .menu li > *:not(ul):not(.menu-title):not(details).active  {
+    @apply bg-orange-900/50 text-white dark:bg-orange-800/80;
 }
 
 form select.select {

--- a/themes/default/js/components/themeSwitch.js
+++ b/themes/default/js/components/themeSwitch.js
@@ -1,50 +1,64 @@
-// Sets the default theme to use on page load.
-const localStorageTheme = localStorage.getItem("theme");
-const systemSettingDark = window.matchMedia("(prefers-color-scheme: dark)");
+htmx.on("htmx:load", function (evt) {
+  // Sets the default theme to use on page load.
+  const cookieTheme = getCookie("theme");
+  const systemSettingDark = window.matchMedia("(prefers-color-scheme: dark)");
 
-let currentThemeSetting = calculateSettingAsThemeString({
-  localStorageTheme,
-  systemSettingDark,
-});
-
-// Set the text on the menu correctly on page load
-const newCta = currentThemeSetting === "my_dark" ? "Light Theme" : "Dark Theme";
-document.querySelectorAll("[data-theme-toggle] > span").innerText = newCta;
-document.querySelector("html").setAttribute("data-theme", currentThemeSetting);
-
-// Add an onClick event to the link
-document.querySelectorAll("[data-theme-toggle]").forEach((e) => {
-  e.addEventListener("click", () => {
-    const newTheme = currentThemeSetting === "my_dark" ? "my_light" : "my_dark";
-
-    // Update the link text
-    const newCta = newTheme === "my_dark" ? "Light Theme" : "Dark Theme";
-    document
-      .querySelectorAll("[data-theme-toggle] > span")
-      .forEach((e) => (e.innerText = newCta));
-
-    // update theme attribute on HTML to switch theme in CSS
-    document.querySelector("html").setAttribute("data-theme", newTheme);
-
-    // update in local storage
-    localStorage.setItem("theme", newTheme);
-
-    // update the currentThemeSetting in memory
-    currentThemeSetting = newTheme;
+  let currentThemeSetting = calculateSettingAsThemeString({
+    cookieTheme,
+    systemSettingDark,
   });
+
+  // Set the appropriate checked state for the theme toggler
+  document.querySelector("input.theme-controller").checked =
+    currentThemeSetting === "light";
+
+  // Store the current theme in a cookie so it can be accessed by both us and the server
+  createCookie("theme", currentThemeSetting, "365");
+
+  // Add an onClick event to the link
+  document.querySelectorAll("input.theme-controller").forEach((e) => {
+    e.addEventListener("click", () => {
+      const newTheme = currentThemeSetting === "dark" ? "light" : "dark";
+
+      // Update our cookie
+      createCookie("theme", newTheme, "365");
+
+      // update the currentThemeSetting in memory
+      currentThemeSetting = newTheme;
+    });
+  });
+
+  function calculateSettingAsThemeString({ cookieTheme, systemSettingDark }) {
+    if (cookieTheme !== null) {
+      return cookieTheme;
+    }
+
+    if (systemSettingDark.matches) {
+      return "dark";
+    }
+
+    return "light";
+  }
 });
 
-function calculateSettingAsThemeString({
-  localStorageTheme,
-  systemSettingDark,
-}) {
-  if (localStorageTheme !== null) {
-    return localStorageTheme;
+function createCookie(name, value, days) {
+  var expires;
+  if (days) {
+    var date = new Date();
+    date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
+    expires = "; expires=" + date.toGMTString();
+  } else {
+    expires = "";
   }
 
-  if (systemSettingDark.matches) {
-    return "my_dark";
-  }
+  document.cookie = name + "=" + value + expires + "; path=/";
+}
 
-  return "my_light";
+function getCookie(cookiename) {
+  // Get name followed by anything except a semicolon
+  var cookiestring = RegExp(cookiename + "=[^;]+").exec(document.cookie);
+  // Return everything after the equal sign, or an empty string if the cookie name not found
+  return decodeURIComponent(
+    !!cookiestring ? cookiestring.toString().replace(/^[^=]+./, "") : "",
+  );
 }

--- a/themes/default/master.php
+++ b/themes/default/master.php
@@ -1,5 +1,6 @@
 <!doctype html>
-<html class="no-js" lang="" data-theme="ci_light">
+<html class="no-js" lang="en" data-theme="<?= get_cookie('theme') ?>">
+
 
 <head>
     <meta charset="utf-8">


### PR DESCRIPTION
- Switched to use the new theme controller in DaisyUI
- Updated javascript to store in a cookie so that we would not see a theme flash when boosted pages were loaded. 
- Moved the account and theme switcher to always show in toolbar even in mobile
- Added styles for menu hovers
- Removed the search field for now. We can add it back in when we need it. 
- Simplified the menu entries for both mobile and desktop views. 
- Updated the theme settings in tailwind.config.js based on new info about overriding values in existing themes. 