### PR TITLE
Trust levels - the beginning

### DIFF
--- a/_docs/trust_levels.md
+++ b/_docs/trust_levels.md
@@ -1,0 +1,25 @@
+# Trust Levels
+
+Trust levels are a way of granting different capabilities to different users based on their activity and engagement with the community. These are inspired by the [trust level system](https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/) used by Discourse.
+
+## Assigning Trust Levels
+
+Trust levels are automatically assigned during a weekly scheduled task (Not implemented yet). The task can be ran manually from the cli with the following command:
+
+```bash
+php spark trust:update
+```
+
+This examines all users and assigns them a trust level which is stored in the `trust_level` column on the `users` table.
+
+## Checking Trust Level
+
+You can check whether a user can be trusted to perform a certain action by using the `canTrustTo()` method on the `User` entity. This method accepts a string as an argument and returns a boolean. For example, to check if a user can flag posts, you would use the following code:
+
+```php
+if ($user->canTrustTo('flag')) {
+    //
+}
+```
+
+A list of all available trust scopes can be found in the `TrustLevels` config class, along with their default trust level requirements. This can be changed by admins and is saved in the database via the `settings` library.

--- a/app/AdminRoutes.php
+++ b/app/AdminRoutes.php
@@ -11,5 +11,6 @@ $routes->group('admin', static function (RouteCollection $routes) {
     // Settings
     $routes->group('settings', static function (RouteCollection $routes) {
         $routes->match(['get', 'post'], 'users', 'Admin\Settings\UsersController::index', ['as' => 'settings-users']);
+        $routes->match(['get', 'post'], 'trust-levels', 'Admin\Settings\TrustLevelsController::index', ['as' => 'settings-trust']);
     });
 });

--- a/app/Config/TrustLevels.php
+++ b/app/Config/TrustLevels.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Config;
+
+use CodeIgniter\Config\BaseConfig;
+
+class TrustLevels extends BaseConfig
+{
+    /**
+     * The actions that trust levels can check against.
+     */
+    public $actions = [
+        'flag' => 'Flag a thread/post',
+        'attach' => 'Attach a file to a thread/post',
+        'link-signature' => 'Have any links in their signature',
+        'start-discussion' => 'Start more than 3 new discussions',
+        'reply' => 'Post more than 10 replies',
+        'edit-own' => 'Edit their own thread/post after 24 hours',
+        'send-pm' => 'Send private messages',
+    ];
+
+    /**
+     * The levels of trust that users can have.
+     */
+    public $levels = [
+        0 => 'New Member',
+        1 => 'Member',
+        2 => 'Regular',
+        3 => 'Leader',
+    ];
+
+    /**
+     * The actions that each trust level is allowed to perform.
+     */
+    public $allowedActions = [
+        0 => [],
+        1 => [
+            'flag',
+            'attach',
+            'link-signature',
+            'start-discussion',
+            'reply',
+            'edit-own',
+            'send-pm',
+        ],
+    ];
+
+    /**
+     * The requirements that a user has to meet to reach a trust level.
+     */
+    public $requirements = [
+        0 => [],
+        1 => [
+            'new-threads' => 5,
+            'read-threads' => 30,
+        ],
+        2 => [
+            'daily-visits' => 15,
+            'likes-given' => 1,
+            'likes-received' => 1,
+            'replies-given' => 3,
+            'new-threads' => 20,
+            'read-threads' => 100,
+        ],
+    ];
+}

--- a/app/Config/TrustLevels.php
+++ b/app/Config/TrustLevels.php
@@ -10,13 +10,13 @@ class TrustLevels extends BaseConfig
      * The actions that trust levels can check against.
      */
     public $actions = [
-        'flag' => 'Flag a thread/post',
-        'attach' => 'Attach a file to a thread/post',
-        'link-signature' => 'Have any links in their signature',
+        'flag'             => 'Flag a thread/post',
+        'attach'           => 'Attach a file to a thread/post',
+        'link-signature'   => 'Have any links in their signature',
         'start-discussion' => 'Start more than 3 new discussions',
-        'reply' => 'Post more than 10 replies',
-        'edit-own' => 'Edit their own thread/post after 24 hours',
-        'send-pm' => 'Send private messages',
+        'reply'            => 'Post more than 10 replies',
+        'edit-own'         => 'Edit their own thread/post after 24 hours',
+        'send-pm'          => 'Send private messages',
     ];
 
     /**
@@ -51,16 +51,16 @@ class TrustLevels extends BaseConfig
     public $requirements = [
         0 => [],
         1 => [
-            'new-threads' => 5,
+            'new-threads'  => 5,
             'read-threads' => 30,
         ],
         2 => [
-            'daily-visits' => 15,
-            'likes-given' => 1,
+            'daily-visits'   => 15,
+            'likes-given'    => 1,
             'likes-received' => 1,
-            'replies-given' => 3,
-            'new-threads' => 20,
-            'read-threads' => 100,
+            'replies-given'  => 3,
+            'new-threads'    => 20,
+            'read-threads'   => 100,
         ],
     ];
 }

--- a/app/Controllers/Admin/Settings/TrustLevelsController.php
+++ b/app/Controllers/Admin/Settings/TrustLevelsController.php
@@ -3,9 +3,7 @@
 namespace App\Controllers\Admin\Settings;
 
 use App\Controllers\AdminController;
-use CodeIgniter\HTTP\ResponseInterface;
 use InvalidArgumentException;
-use RuntimeException;
 
 class TrustLevelsController extends AdminController
 {
@@ -14,14 +12,14 @@ class TrustLevelsController extends AdminController
      */
     public function index()
     {
-        if($this->request->getMethod() === 'post') {
+        if ($this->request->getMethod() === 'post') {
             return $this->update();
         }
 
         return $this->render('admin/settings/trust_levels', [
-            'trustLevels'  => setting('TrustLevels.levels'),
-            'trustActions' => setting('TrustLevels.actions'),
-            'trustAllowed' => setting('TrustLevels.allowedActions'),
+            'trustLevels'       => setting('TrustLevels.levels'),
+            'trustActions'      => setting('TrustLevels.actions'),
+            'trustAllowed'      => setting('TrustLevels.allowedActions'),
             'trustRequirements' => setting('TrustLevels.requirements'),
         ]);
     }
@@ -32,24 +30,24 @@ class TrustLevelsController extends AdminController
     private function update()
     {
         $this->validateData($this->request->getPost(), [
-            'trust' => 'required',
+            'trust'        => 'required',
             'requirements' => 'required',
         ]);
 
-        $trust = $this->request->getPost('trust');
+        $trust        = $this->request->getPost('trust');
         $requirements = $this->request->getPost('requirements');
 
-        $trustLevels = setting('TrustLevels.levels');
+        $trustLevels  = setting('TrustLevels.levels');
         $trustActions = setting('TrustLevels.actions');
 
         // Ensure the trust levels and actions are valid
         foreach ($trust as $level => $actions) {
-            if (!isset($trustLevels[$level])) {
+            if (! isset($trustLevels[$level])) {
                 throw new InvalidArgumentException('Invalid trust level: ' . $level);
             }
 
             foreach ($actions as $action => $value) {
-                if (!isset($trustActions[$action])) {
+                if (! isset($trustActions[$action])) {
                     throw new InvalidArgumentException('Invalid trust action: ' . $action);
                 }
             }
@@ -57,7 +55,7 @@ class TrustLevelsController extends AdminController
 
         // Ensure the requirements are valid
         foreach ($requirements as $level => $values) {
-            if (!isset($trustLevels[$level])) {
+            if (! isset($trustLevels[$level])) {
                 throw new InvalidArgumentException('Invalid trust level: ' . $level);
             }
         }

--- a/app/Controllers/Admin/Settings/TrustLevelsController.php
+++ b/app/Controllers/Admin/Settings/TrustLevelsController.php
@@ -12,7 +12,7 @@ class TrustLevelsController extends AdminController
      */
     public function index()
     {
-        if ($this->request->getMethod() === 'post') {
+        if ($this->request->is('post')) {
             return $this->update();
         }
 

--- a/app/Controllers/Admin/Settings/TrustLevelsController.php
+++ b/app/Controllers/Admin/Settings/TrustLevelsController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Controllers\Admin\Settings;
+
+use App\Controllers\AdminController;
+use CodeIgniter\HTTP\ResponseInterface;
+use InvalidArgumentException;
+use RuntimeException;
+
+class TrustLevelsController extends AdminController
+{
+    /**
+     * Display the trust levels settings page.
+     */
+    public function index()
+    {
+        if($this->request->getMethod() === 'post') {
+            return $this->update();
+        }
+
+        return $this->render('admin/settings/trust_levels', [
+            'trustLevels'  => setting('TrustLevels.levels'),
+            'trustActions' => setting('TrustLevels.actions'),
+            'trustAllowed' => setting('TrustLevels.allowedActions'),
+            'trustRequirements' => setting('TrustLevels.requirements'),
+        ]);
+    }
+
+    /**
+     * Update the trust levels settings.
+     */
+    private function update()
+    {
+        $this->validateData($this->request->getPost(), [
+            'trust' => 'required',
+            'requirements' => 'required',
+        ]);
+
+        $trust = $this->request->getPost('trust');
+        $requirements = $this->request->getPost('requirements');
+
+        $trustLevels = setting('TrustLevels.levels');
+        $trustActions = setting('TrustLevels.actions');
+
+        // Ensure the trust levels and actions are valid
+        foreach ($trust as $level => $actions) {
+            if (!isset($trustLevels[$level])) {
+                throw new InvalidArgumentException('Invalid trust level: ' . $level);
+            }
+
+            foreach ($actions as $action => $value) {
+                if (!isset($trustActions[$action])) {
+                    throw new InvalidArgumentException('Invalid trust action: ' . $action);
+                }
+            }
+        }
+
+        // Ensure the requirements are valid
+        foreach ($requirements as $level => $values) {
+            if (!isset($trustLevels[$level])) {
+                throw new InvalidArgumentException('Invalid trust level: ' . $level);
+            }
+        }
+
+        // Ensure each trust level's allowed actions are converted to an array of the keys
+        foreach ($trust as $level => $actions) {
+            $trust[$level] = array_keys($actions);
+        }
+
+        setting('TrustLevels.allowedActions', $trust);
+        setting('TrustLevels.requirements', $requirements);
+
+        return redirect()->to(current_url())
+            ->with('success', lang('Admin.settingsUpdated'));
+    }
+}

--- a/app/Database/Migrations/2024-02-05-052646_AddTrustLevelsToUsers.php
+++ b/app/Database/Migrations/2024-02-05-052646_AddTrustLevelsToUsers.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class AddTrustLevelsToUsers extends Migration
+{
+    public function up()
+    {
+        // Add the field 'trust_level' to the 'users' table
+        $this->forge->addColumn('users', [
+            'trust_level' => [
+                'type'       => 'TINYINT',
+                'constraint' => 1,
+                'default'    => 0,
+                'after'      => 'timezone',
+            ],
+        ]);
+    }
+
+    public function down()
+    {
+        // Drop the field 'trust_level' from the 'users' table
+        $this->forge->dropColumn('users', 'trust_level');
+    }
+}

--- a/app/Entities/User.php
+++ b/app/Entities/User.php
@@ -7,8 +7,6 @@ use CodeIgniter\HTTP\Files\UploadedFile;
 use CodeIgniter\Shield\Entities\Login;
 use CodeIgniter\Shield\Entities\User as ShieldUser;
 use CodeIgniter\Shield\Models\LoginModel;
-use InvalidArgumentException;
-use RuntimeException;
 
 class User extends ShieldUser
 {
@@ -162,6 +160,6 @@ class User extends ShieldUser
         }
 
         // Ensure they're allowed this action.
-        return in_array($action, setting('TrustLevels.allowedActions')[$trustLevel]);
+        return in_array($action, setting('TrustLevels.allowedActions')[$trustLevel], true);
     }
 }

--- a/app/Entities/User.php
+++ b/app/Entities/User.php
@@ -7,6 +7,8 @@ use CodeIgniter\HTTP\Files\UploadedFile;
 use CodeIgniter\Shield\Entities\Login;
 use CodeIgniter\Shield\Entities\User as ShieldUser;
 use CodeIgniter\Shield\Models\LoginModel;
+use InvalidArgumentException;
+use RuntimeException;
 
 class User extends ShieldUser
 {
@@ -145,5 +147,21 @@ class User extends ShieldUser
             ->write($path, file_get_contents($file->getTempName()));
 
         return $path;
+    }
+
+    /**
+     * Checks if the user can be trusted to peform the given action.
+     */
+    public function canTrustTo(string $action): bool
+    {
+        $trustLevel = $this->trust_level;
+
+        // Ensure it's a valid trust level
+        if (! array_key_exists($trustLevel, setting('TrustLevels.allowedActions'))) {
+            return false;
+        }
+
+        // Ensure they're allowed this action.
+        return in_array($action, setting('TrustLevels.allowedActions')[$trustLevel]);
     }
 }

--- a/app/Libraries/Storage.php
+++ b/app/Libraries/Storage.php
@@ -37,7 +37,7 @@ class Storage
     /**
      * Get a filesystem instance.
      */
-    public function disk(string $disk = 'default'): FileSystem
+    public function disk(string $disk = 'default'): Filesystem
     {
         if ($disk === 'default') {
             $disk = $this->default;
@@ -55,7 +55,7 @@ class Storage
      *
      * @throws InvalidArgumentException
      */
-    private function createDisk(string $disk): FileSystem
+    private function createDisk(string $disk): Filesystem
     {
         $config = $this->config->disks[$disk] ?? null;
 

--- a/app/Views/admin/settings/trust_levels.php
+++ b/app/Views/admin/settings/trust_levels.php
@@ -1,0 +1,65 @@
+<?= $this->extend('master') ?>
+
+<?= $this->section('main'); ?>
+    <h1 class="text-lg font-semibold mb-4">Trust Levels Settings</h1>
+
+    <div id="form-wrap">
+        <form action="<?= current_url() ?>" method="post">
+            <?= csrf_field() ?>
+
+            <!-- Loop over each trust level as a field group -->
+            <?php foreach ($trustLevels as $level => $trustLevel): ?>
+                <fieldset>
+                    <legend>Level <?= $level ?></legend>
+
+                    <div class="flex flex-row gap-6">
+                        <div class="w-1/2">
+                        <?php if (!empty($trustRequirements[$level])) : ?>
+                            <h3 class="font-semibold mb-2">Requirements:</h3>
+
+                            <?php foreach($trustRequirements[$level] ?? [] as $requirement => $value): ?>
+                                <div class="ml-4 mb-1">
+                                    <label for="trust-<?= $level ?>-<?= $requirement ?>">
+                                        <input type="number"
+                                            class="border border-gray-300 rounded py-1 px-2 mr-2"
+                                            id="trust-<?= $level ?>-<?= $requirement ?>"
+                                            name="requirements[<?= $level ?>][<?= $requirement ?>]"
+                                            value="<?= $value ?>"
+                                        >
+                                        <?= ucwords(str_replace('-', ' ', $requirement)) ?>
+                                    </label>
+                                </div>
+                            <?php endforeach; ?>
+                        <?php endif; ?>
+                    </div>
+
+                    <div class="w-1/2">
+                        <h3 class="font-semibold mb-2">Allowed Actions:</h3>
+
+                        <?php foreach ($trustActions as $action => $label): ?>
+                            <div class="ml-4">
+                                <label for="trust-<?= $level ?>-<?= $action ?>">
+                                    <input type="checkbox"
+                                        class="mr-2"
+                                        id="trust-<?= $level ?>-<?= $action ?>"
+                                        name="trust[<?= $level ?>][<?= $action ?>]"
+                                        value="1"
+                                        <?= in_array($action, $trustAllowed[$level] ?? []) ? 'checked' : '' ?>
+                                    >
+                                    <?= $label ?>
+                                </label>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                </fieldset>
+            <?php endforeach; ?>
+
+            <div class="flex <?= (auth()->user()?->handed ?? 'right') === 'right' ? 'justify-end' : 'justify-start' ?>">
+                <button type="submit" class="btn btn-primary" data-loading-disable>
+                    Save Trust Levels
+                </button>
+            </div>
+        </form>
+    </div>
+
+<?= $this->endSection(); ?>

--- a/tests/Controllers/Admin/TrustLevelsSettingsTest.php
+++ b/tests/Controllers/Admin/TrustLevelsSettingsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Controllers\Admin;
+namespace Tests\Controllers\Admin;
 
 use App\Entities\User;
 use App\Models\Factories\UserFactory;

--- a/tests/Controllers/Admin/TrustLevelsSettingsTest.php
+++ b/tests/Controllers/Admin/TrustLevelsSettingsTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Controllers\Admin;
+
+use App\Entities\User;
+use App\Libraries\Authentication\Actions\Email2FA;
+use App\Models\Factories\UserFactory;
+use CodeIgniter\Shield\Authentication\Actions\EmailActivator;
+use Exception;
+use Tests\Support\Database\Seeds\TestDataSeeder;
+use Tests\Support\TestCase;
+
+/**
+ * @internal
+ */
+final class TrustLevelsSettingsTest extends TestCase
+{
+    protected $seed = TestDataSeeder::class;
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var User $user */
+        $user = fake(UserFactory::class, [
+            'password' => 'secret123',
+        ]);
+        $this->user = $user;
+        $this->user->addGroup('superadmin');
+
+        // Ensure we have a clean slate for the settings
+        setting()->forget('TrustLevels.allowedActions');
+        setting()->forget('TrustLevels.requirements');
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testVisitGuest()
+    {
+        $response = $this->get(route_to('settings-trust'));
+
+        $response->assertRedirect();
+        // Will return a normal redirect from the Sheild
+        $response->assertHeader('Location', url_to('login'));
+    }
+
+    public function testViewUserSettings()
+    {
+        $response = $this->actingAs($this->user)->get(route_to('settings-trust'));
+
+        // See some basic headers on the page when it displays properly
+        $response->assertSee('Trust Levels Settings');
+        $response->assertSee('Level 0');
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testUserSettings()
+    {
+        // Check default state on a couple elements
+        $this->assertFalse(in_array('flag', setting('TrustLevels.allowedActions')[0]));
+        $this->assertTrue(in_array('attach', setting('TrustLevels.allowedActions')[1]));
+        $this->assertEquals(setting('TrustLevels.requirements')[1]['new-threads'], 5);
+
+        // Submit the form with some new values
+        $response = $this
+            ->withHeaders([csrf_header() => csrf_hash()])
+            ->actingAs($this->user)
+            ->post('admin/settings/trust-levels', [
+                'trust' => [
+                    0 => ['flag' => 1],
+                    1 => []
+                ],
+                'requirements' => [
+                    1 => ['new-threads' => 15],
+                ],
+            ]);
+
+        $response->assertOK();
+
+        // Check that the settings were saved
+        $this->assertTrue(in_array('flag', setting('TrustLevels.allowedActions')[0]));
+        $this->assertFalse(in_array('attach', setting('TrustLevels.allowedActions')[1]));
+        $this->assertEquals(setting('TrustLevels.requirements')[1]['new-threads'], 15);
+    }
+}

--- a/tests/Controllers/Admin/TrustLevelsSettingsTest.php
+++ b/tests/Controllers/Admin/TrustLevelsSettingsTest.php
@@ -3,9 +3,7 @@
 namespace Controllers\Admin;
 
 use App\Entities\User;
-use App\Libraries\Authentication\Actions\Email2FA;
 use App\Models\Factories\UserFactory;
-use CodeIgniter\Shield\Authentication\Actions\EmailActivator;
 use Exception;
 use Tests\Support\Database\Seeds\TestDataSeeder;
 use Tests\Support\TestCase;
@@ -61,9 +59,9 @@ final class TrustLevelsSettingsTest extends TestCase
     public function testUserSettings()
     {
         // Check default state on a couple elements
-        $this->assertFalse(in_array('flag', setting('TrustLevels.allowedActions')[0]));
-        $this->assertTrue(in_array('attach', setting('TrustLevels.allowedActions')[1]));
-        $this->assertEquals(setting('TrustLevels.requirements')[1]['new-threads'], 5);
+        $this->assertFalse(in_array('flag', setting('TrustLevels.allowedActions')[0], true));
+        $this->assertTrue(in_array('attach', setting('TrustLevels.allowedActions')[1], true));
+        $this->assertSame(setting('TrustLevels.requirements')[1]['new-threads'], 5);
 
         // Submit the form with some new values
         $response = $this
@@ -72,7 +70,7 @@ final class TrustLevelsSettingsTest extends TestCase
             ->post('admin/settings/trust-levels', [
                 'trust' => [
                     0 => ['flag' => 1],
-                    1 => []
+                    1 => [],
                 ],
                 'requirements' => [
                     1 => ['new-threads' => 15],
@@ -82,8 +80,8 @@ final class TrustLevelsSettingsTest extends TestCase
         $response->assertOK();
 
         // Check that the settings were saved
-        $this->assertTrue(in_array('flag', setting('TrustLevels.allowedActions')[0]));
-        $this->assertFalse(in_array('attach', setting('TrustLevels.allowedActions')[1]));
-        $this->assertEquals(setting('TrustLevels.requirements')[1]['new-threads'], 15);
+        $this->assertTrue(in_array('flag', setting('TrustLevels.allowedActions')[0], true));
+        $this->assertFalse(in_array('attach', setting('TrustLevels.allowedActions')[1], true));
+        $this->assertSame(setting('TrustLevels.requirements')[1]['new-threads'], 15);
     }
 }

--- a/tests/Entities/UserTest.php
+++ b/tests/Entities/UserTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Entities;
+
+use App\Entities\User;
+use Tests\Support\TestCase;
+
+class UserTest extends TestCase
+{
+    public function testCanTrustTo()
+    {
+        $user = new User([
+            'trust_level' => null,
+        ]);
+
+        // Should fail nicely when no trust level is set
+        $this->assertFalse($user->canTrustTo('flag'));
+
+        // Should return false with a valid action, but not at the right level
+        $user->trust_level = 0;
+        $this->assertFalse($user->canTrustTo('attach'));
+
+        // Should return false with a non-action
+        $user->trust_level = 1;
+        $this->assertFalse($user->canTrustTo(1));
+
+        // Should return true with a valid action
+        $this->assertTrue($user->canTrustTo('flag'));
+    }
+}

--- a/tests/Entities/UserTest.php
+++ b/tests/Entities/UserTest.php
@@ -5,7 +5,10 @@ namespace Tests\Entities;
 use App\Entities\User;
 use Tests\Support\TestCase;
 
-class UserTest extends TestCase
+/**
+ * @internal
+ */
+final class UserTest extends TestCase
 {
     public function testCanTrustTo()
     {

--- a/themes/admin/_sidebar.php
+++ b/themes/admin/_sidebar.php
@@ -11,6 +11,11 @@
                     Users
                 </a>
             </li>
+            <li>
+                <a href="<?= url_to('settings-trust') ?>">
+                    Trust Levels
+                </a>
+            </li>
         </menu>
     </div>
 </nav>


### PR DESCRIPTION
- Config file to define trust levels/requirements/actions/etc
- `canTrustTo()` method on the User entity for checking trust actions.
- Trust Levels settings page in the admin. 

Note: the actions/requirements for these levels are not complete, but are included as a starting point. This will change as actual trust level restrictions are implemented in the code. 