### PR TITLE
feat(app): Ensure that trust levels are checked in order to report a discussion

### DIFF
--- a/_docs/trust_levels.md
+++ b/_docs/trust_levels.md
@@ -14,10 +14,10 @@ This examines all users and assigns them a trust level which is stored in the `t
 
 ## Checking Trust Level
 
-You can check whether a user can be trusted to perform a certain action by using the `canTrustTo()` method on the `User` entity. This method accepts a string as an argument and returns a boolean. For example, to check if a user can flag posts, you would use the following code:
+You can check whether a user can be trusted to perform a certain action by using the `canTrustTo()` method on the `User` entity. This method accepts a string as an argument and returns a boolean. For example, to check if a user can report posts, you would use the following code:
 
 ```php
-if ($user->canTrustTo('flag')) {
+if ($user->canTrustTo('report')) {
     //
 }
 ```

--- a/app/Config/Auth.php
+++ b/app/Config/Auth.php
@@ -373,7 +373,7 @@ class Auth extends ShieldAuth
      *
      * Valid range is between 4 - 31.
      */
-    public int $hashCost = 12;
+    public int $hashCost = ENVIRONMENT == 'testing' ? 4 : 12;
 
     /**
      * If you need to support passwords saved in versions prior to Shield v1.0.0-beta.4.

--- a/app/Config/TrustLevels.php
+++ b/app/Config/TrustLevels.php
@@ -10,7 +10,7 @@ class TrustLevels extends BaseConfig
      * The actions that trust levels can check against.
      */
     public $actions = [
-        'flag'             => 'Flag a thread/post',
+        'report'           => 'Report a thread/post',
         'attach'           => 'Attach a file to a thread/post',
         'link-signature'   => 'Have any links in their signature',
         'start-discussion' => 'Start more than 3 new discussions',
@@ -35,7 +35,7 @@ class TrustLevels extends BaseConfig
     public $allowedActions = [
         0 => [],
         1 => [
-            'flag',
+            'report',
             'attach',
             'link-signature',
             'start-discussion',

--- a/app/Models/Factories/UserFactory.php
+++ b/app/Models/Factories/UserFactory.php
@@ -21,6 +21,7 @@ class UserFactory extends UserModel
             'active'   => true,
             'country'  => $faker->countryCode,
             'timezone' => $faker->timezone,
+            'trust_level' => 0,
         ]);
     }
 

--- a/app/Policies/ContentPolicy.php
+++ b/app/Policies/ContentPolicy.php
@@ -15,6 +15,11 @@ class ContentPolicy implements PolicyInterface
     public function report(User $user, Post|Thread $record): bool
     {
         // Can't report your own content.
-        return $user->id !== $record->author_id;
+        if ($user->id == $record->author_id) {
+            return false;
+        }
+
+        // Otherwise, base it on the user's trust level.
+        return $user->canTrustTo('report');
     }
 }

--- a/tests/Cells/ActionBarTest.php
+++ b/tests/Cells/ActionBarTest.php
@@ -75,7 +75,11 @@ final class ActionBarTest extends TestCase
         // User should be able to manage the answer to a thread.
         $this->assertFalse($this->cell->canManageAnswer());
 
-        // Can report someone else's thread.
+        // Can NOT report a thread with a default trust level.
+        $this->assertFalse($this->cell->canReport());
+
+        // Can report someone else's thread with a higher trust level.
+        $this->user->trust_level = 1;
         $this->assertTrue($this->cell->canReport());
     }
 
@@ -149,11 +153,15 @@ final class ActionBarTest extends TestCase
         // Should be able to reply to other post.
         $this->assertTrue($this->cell->canReply());
 
-        // Should be able to report other post.
-        $this->assertTrue($this->cell->canReport());
-
         // Since it's your thread, you should be able to manage the answer.
         $this->assertTrue($this->cell->canManageAnswer());
+
+        // Should NOT be able to report other post with a default trust level.
+        $this->assertFalse($this->cell->canReport());
+
+        // Should be able to report other post with a higher trust level.
+        $this->user->trust_level = 1;
+        $this->assertTrue($this->cell->canReport());
 
         // Should not be able to manage the answer on someone else's thread.
         $post->thread_id = $otherThread->id;

--- a/tests/Controllers/Admin/TrustLevelsSettingsTest.php
+++ b/tests/Controllers/Admin/TrustLevelsSettingsTest.php
@@ -59,7 +59,7 @@ final class TrustLevelsSettingsTest extends TestCase
     public function testUserSettings()
     {
         // Check default state on a couple elements
-        $this->assertFalse(in_array('flag', setting('TrustLevels.allowedActions')[0], true));
+        $this->assertFalse(in_array('report', setting('TrustLevels.allowedActions')[0], true));
         $this->assertTrue(in_array('attach', setting('TrustLevels.allowedActions')[1], true));
         $this->assertSame(setting('TrustLevels.requirements')[1]['new-threads'], 5);
 
@@ -69,7 +69,7 @@ final class TrustLevelsSettingsTest extends TestCase
             ->actingAs($this->user)
             ->post('admin/settings/trust-levels', [
                 'trust' => [
-                    0 => ['flag' => 1],
+                    0 => ['report' => 1],
                     1 => [],
                 ],
                 'requirements' => [
@@ -80,7 +80,7 @@ final class TrustLevelsSettingsTest extends TestCase
         $response->assertOK();
 
         // Check that the settings were saved
-        $this->assertTrue(in_array('flag', setting('TrustLevels.allowedActions')[0], true));
+        $this->assertTrue(in_array('report', setting('TrustLevels.allowedActions')[0], true));
         $this->assertFalse(in_array('attach', setting('TrustLevels.allowedActions')[1], true));
         $this->assertSame(setting('TrustLevels.requirements')[1]['new-threads'], 15);
     }

--- a/tests/Controllers/ReportControllerTest.php
+++ b/tests/Controllers/ReportControllerTest.php
@@ -24,6 +24,7 @@ final class ReportControllerTest extends TestCase
         /** @var User $user */
         $user = fake(UserFactory::class, [
             'password' => 'secret123',
+            'trust_level' => 0,
         ]);
         $this->user = $user;
         $this->user->addGroup('admin');
@@ -61,6 +62,8 @@ final class ReportControllerTest extends TestCase
      */
     public function testReportGet()
     {
+        $this->user->trust_level = 1;
+
         $response = $this->withHeaders([
             'HX-Request' => 'true',
         ])->actingAs($this->user)->get(route_to('thread-report', 1));
@@ -73,6 +76,8 @@ final class ReportControllerTest extends TestCase
      */
     public function testReportPost()
     {
+        $this->user->trust_level = 1;
+
         $response = $this->withHeaders([
             csrf_header() => csrf_hash(),
             'HX-Request'  => 'true',
@@ -88,6 +93,8 @@ final class ReportControllerTest extends TestCase
      */
     public function testReportPostEmptyComment()
     {
+        $this->user->trust_level = 1;
+
         $response = $this->withHeaders([
             csrf_header() => csrf_hash(),
             'HX-Request'  => 'true',
@@ -102,6 +109,8 @@ final class ReportControllerTest extends TestCase
      */
     public function testReportPostTooManyReports()
     {
+        $this->user->trust_level = 1;
+
         config(Forum::class)->maxReportsPerDey = 1;
         service('throttler')->check(md5('report-' . $this->user->id), config(Forum::class)->maxReportsPerDey, DAY);
 

--- a/tests/Entities/UserTest.php
+++ b/tests/Entities/UserTest.php
@@ -17,7 +17,7 @@ final class UserTest extends TestCase
         ]);
 
         // Should fail nicely when no trust level is set
-        $this->assertFalse($user->canTrustTo('flag'));
+        $this->assertFalse($user->canTrustTo('report'));
 
         // Should return false with a valid action, but not at the right level
         $user->trust_level = 0;
@@ -28,6 +28,6 @@ final class UserTest extends TestCase
         $this->assertFalse($user->canTrustTo(1));
 
         // Should return true with a valid action
-        $this->assertTrue($user->canTrustTo('flag'));
+        $this->assertTrue($user->canTrustTo('report'));
     }
 }


### PR DESCRIPTION
Ensure that trust levels are checked in order to report a discussion. 

This adds `$user->canTrustTo()` to `ContentPolicy` and adjusts relevant tests. 