### PR TITLE
Signature trust

### DIFF
--- a/app/Concerns/RendersContent.php
+++ b/app/Concerns/RendersContent.php
@@ -3,6 +3,7 @@
 namespace App\Concerns;
 
 use App\Libraries\TextFormatter;
+use DOMDocument;
 
 trait RendersContent
 {
@@ -11,9 +12,56 @@ trait RendersContent
      */
     public function render(): string
     {
-        return match ($this->markup) {
-            'bbcode' => TextFormatter::instance()->renderBBCode($this->body),
-            default  => TextFormatter::instance()->renderMarkdown($this->body),
-        };
+        $cacheKey = $this->cacheKey('-body');
+
+        if (! $content = cache($cacheKey)) {
+            $content = match ($this->markup) {
+                'bbcode' => TextFormatter::instance()->renderBBCode($this->body),
+                default  => TextFormatter::instance()->renderMarkdown($this->body),
+            };
+
+            $content = $this->nofollowLinks($content);
+
+            cache()->save($cacheKey, $content, MONTH);
+        }
+
+        return $content;
+    }
+
+    /**
+     * Strips all anchor tags from the given HTML.
+     *
+     * Used mostly to strip out links from the rendered content
+     * when not allowed by the user's trust level.
+     */
+    public function stripAnchors(string $html): string
+    {
+        $xml = new DOMDocument();
+        $xml->loadHTML($html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+
+        foreach ($xml->getElementsByTagName('a') as $anchor) {
+            $anchor->parentNode->replaceChild($xml->createTextNode($anchor->nodeValue), $anchor);
+        }
+
+        return $xml->saveHTML();
+    }
+
+    /**
+     * Adds `rel="nofollow"` to all anchor tags in the given HTML.
+     * Also ensures all links open in a new tab.
+     *
+     * Used for most user-generated content to prevent spam.
+     */
+    public function nofollowLinks(string $html): string
+    {
+        $xml = new DOMDocument();
+        $xml->loadHTML($html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+
+        foreach ($xml->getElementsByTagName('a') as $anchor) {
+            $anchor->setAttribute('rel', 'nofollow');
+            $anchor->setAttribute('target', '_blank');
+        }
+
+        return $xml->saveHTML();
     }
 }

--- a/app/Config/Cache.php
+++ b/app/Config/Cache.php
@@ -21,7 +21,7 @@ class Cache extends BaseConfig
      * The name of the preferred handler that should be used. If for some reason
      * it is not available, the $backupHandler will be used in its place.
      */
-    public string $handler = 'file';
+    public string $handler = 'dummy';
 
     /**
      * --------------------------------------------------------------------------

--- a/app/Controllers/Account/AccountController.php
+++ b/app/Controllers/Account/AccountController.php
@@ -5,6 +5,7 @@ namespace App\Controllers\Account;
 use App\Controllers\BaseController;
 use App\Entities\NotificationSetting;
 use App\Entities\User;
+use App\Libraries\CacheUtils;
 use App\Models\NotificationSettingModel;
 use App\Models\PostModel;
 use App\Models\ThreadModel;
@@ -136,6 +137,11 @@ class AccountController extends BaseController
                 } catch (FilesystemException $e) {
                     alerts()->set('error', $e->getMessage());
                 }
+            }
+
+            // If the signature has been changed, invalidate the cache.
+            if ($user->hasChanged('signature')) {
+                CacheUtils::invalidateSignatureCache($user);
             }
 
             if (model(UserModel::class)->save($user)) {

--- a/app/Entities/Post.php
+++ b/app/Entities/Post.php
@@ -76,4 +76,9 @@ class Post extends Entity
     {
         return $this->attributes['deleted_at'] !== null || $this->isMarkedAsDeleted();
     }
+
+    public function cacheKey(string $suffix = ''): string
+    {
+        return 'post-' . $this->id . $suffix;
+    }
 }

--- a/app/Entities/Thread.php
+++ b/app/Entities/Thread.php
@@ -55,4 +55,9 @@ class Thread extends Entity
     {
         return $this->attributes['deleted_at'] !== null;
     }
+
+    public function cacheKey(string $suffix = ''): string
+    {
+        return 'post-' . $this->id . $suffix;
+    }
 }

--- a/app/Entities/User.php
+++ b/app/Entities/User.php
@@ -37,7 +37,7 @@ class User extends ShieldUser
         return route_to('profile', $this->username);
     }
 
-    public function cacheKey(string $suffix=''): string
+    public function cacheKey(string $suffix = ''): string
     {
         return 'user-' . $this->id . $suffix;
     }

--- a/app/Libraries/CacheUtils.php
+++ b/app/Libraries/CacheUtils.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Libraries;
+
+use App\Entities\User;
+use App\Models\PostModel;
+use App\Models\ThreadModel;
+
+/**
+ * Provides tools for invalidating caches and other cache-related tasks.
+ */
+class CacheUtils
+{
+    /**
+     * Invalidates the cache for the given user's signature.
+     * This also requires invalidating the thread/post caches
+     * for any posts/threads that the user has made.
+     */
+    public static function invalidateSignatureCache(User $user): void
+    {
+        cache()->delete($user->cacheKey('-sig'));
+
+        // Invalidate the cache for all posts authored by this user.
+        $postIds = model(PostModel::class)->where('author_id', $user->id)->findColumn('id');
+        if (is_array($postIds) && $postIds !== []) {
+            foreach ($postIds as $postId) {
+                cache()->deleteMatching('post-' . $postId . '*');
+            }
+        }
+
+        // Invalidate the cache fo all threads authored by this user.
+        $threadIds = model(ThreadModel::class)->where('author_id', $user->id)->findColumn('id');
+        if (is_array($threadIds) && $threadIds !== []) {
+            foreach ($threadIds as $threadId) {
+                cache()->deleteMatching('thread-' . $threadId . '*');
+            }
+        }
+    }
+}

--- a/app/Models/UserModel.php
+++ b/app/Models/UserModel.php
@@ -23,7 +23,7 @@ class UserModel extends ShieldUser
         parent::initialize();
 
         // Merge properties with parent
-        $this->allowedFields = [...$this->allowedFields, 'handed', 'thread_count', 'post_count', 'avatar', 'country', 'timezone', 'name', 'company', 'location', 'website', 'signature', 'two_factor_auth_email', 'reaction_count',
+        $this->allowedFields = [...$this->allowedFields, 'handed', 'thread_count', 'post_count', 'avatar', 'country', 'timezone', 'name', 'company', 'location', 'website', 'signature', 'two_factor_auth_email', 'reaction_count', 'trust_level',
         ];
 
         // Add event after insert

--- a/themes/default/css/app.scss
+++ b/themes/default/css/app.scss
@@ -106,6 +106,10 @@ label.error {
     }
 }
 
+.signature a {
+    @apply underline hover:text-primary;
+}
+
 // ensure vendor prefix for Chrome and masks
 // These seem to have been dropped recently.
 .mask-squircle {

--- a/themes/default/discussions/_signature.php
+++ b/themes/default/discussions/_signature.php
@@ -1,0 +1,5 @@
+<?php if ($user && $user->signature): ?>
+    <div class="signature text-sm border-t mt-4 py-4">
+        <?= $user->renderSignature() ?>
+    </div>
+<?php endif ?>

--- a/themes/default/discussions/posts/_post.php
+++ b/themes/default/discussions/posts/_post.php
@@ -3,7 +3,7 @@
 >
 
     <!-- Answer Bar -->
-    <?php if(isset($standaloneAnswer)) : ?>
+    <?php if (isset($standaloneAnswer)) : ?>
         <div class="answer-bar">
             <?= view('icons/check-badge') ?> &nbsp;
             Accepted Answer
@@ -42,10 +42,12 @@
             <i>Message not available.</i>
         <?php else: ?>
             <?= $post->render() ?>
+
+            <?= $this->view('discussions/_signature', ['user' => $post->author]) ?>
         <?php endif; ?>
     </div>
 
-    <?php if(! isset($standaloneAnswer)) : ?>
+    <?php if (! isset($standaloneAnswer)) : ?>
         <?= view_cell('ActionBarCell', ['record' => $post]) ?>
     <?php endif ?>
 </div>

--- a/themes/default/discussions/threads/_thread.php
+++ b/themes/default/discussions/threads/_thread.php
@@ -36,6 +36,8 @@
             <?= $thread->render() ?>
         </div>
 
+        <?= $this->view('discussions/_signature', ['user' => $thread->author]) ?>
+
         <?= view_cell('ActionBarCell', ['record' => $thread]) ?>
     </div>
 </div>


### PR DESCRIPTION
- Display author signatures on posts and threads
- Render the signatures with Markdown
- Ensure all links for post/thread content and signatures are nofollow and open in new tab
- Trust levels define whether links can be displayed within a user's signature
- setup caching for post/thread bodies and signatures