### PR TITLE
feat(app): Implement the trust level restrictions on starting a new discussion

### DIFF
--- a/app/Policies/ThreadPolicy.php
+++ b/app/Policies/ThreadPolicy.php
@@ -5,11 +5,22 @@ namespace App\Policies;
 use App\Entities\Thread;
 use App\Entities\User;
 use App\Libraries\Policies\PolicyInterface;
+use Config\TrustLevels;
 use InvalidArgumentException;
 use RuntimeException;
 
 class ThreadPolicy implements PolicyInterface
 {
+    public function create(User $user): bool
+    {
+        $hasTrust = $user->canTrustTo('start-discussion');
+        if (! $hasTrust && $user->thread_count >= TrustLevels::THREAD_THRESHOLD) {
+            return false;
+        }
+
+        return $user->can('threads.create');
+    }
+
     /**
      * Determines if the current user can edit a thread.
      */

--- a/themes/default/discussions/_sidebar.php
+++ b/themes/default/discussions/_sidebar.php
@@ -1,4 +1,4 @@
-<?php if (auth()->user()?->can('threads.create')): ?>
+<?php if (policy('threads.create')): ?>
     <div class="w-full" hx-boost="true">
         <a class="btn btn-primary mt-4 mb-8 w-full" href="<?= url_to('thread-create'); ?>">
             Start a Discussion

--- a/themes/default/discussions/categories/get.php
+++ b/themes/default/discussions/categories/get.php
@@ -11,9 +11,9 @@
 
 <?= $this->section('sidebar')  ?>
 
-<?php if (auth()->user()?->can('threads.create')): ?>
+<?php if (policy('threads.create')): ?>
     <div class="py-4" hx-boost="true">
-        <a class="btn btn-primary mt-4 w-full" href="<?= url_to('thread-create'); ?>"">
+        <a class="btn btn-primary mt-4 w-full" href="<?= url_to('thread-create'); ?>">
         Start a Discussion
         </a>
     </div>


### PR DESCRIPTION
- Added policy for creating a discussion
- check the policy around the `Start a Discussion` button