### PR TITLE
feat(app): Track the number of daily visits for a user over the last 100 days

### DIFF
--- a/app/Commands/UpdateVisits.php
+++ b/app/Commands/UpdateVisits.php
@@ -2,6 +2,7 @@
 
 namespace App\Commands;
 
+use Exception;
 use App\Models\UserModel;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
@@ -64,7 +65,7 @@ class UpdateVisits extends BaseCommand
         // all users that have a last_active date of today.
         model(UserModel::class)
             ->where('last_active', date('Y-m-d'))
-            ->chunk(100, function ($users) use ($db) {
+            ->chunk(100, static function ($users) use ($db) {
                 foreach ($users as $user) {
                     try {
                         $db->table('user_visits')
@@ -72,7 +73,7 @@ class UpdateVisits extends BaseCommand
                                 'user_id' => $user->id,
                                 'visited_on' => date('Y-m-d'),
                             ]);
-                    } catch (\Exception $e) {
+                    } catch (Exception $e) {
                         log_message('error', 'Error updating user visits: '. $e->getMessage());
                     }
                 }

--- a/app/Commands/UpdateVisits.php
+++ b/app/Commands/UpdateVisits.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Commands;
+
+use App\Models\UserModel;
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\CLI;
+use CodeIgniter\I18n\Time;
+
+class UpdateVisits extends BaseCommand
+{
+    /**
+     * The Command's Group
+     *
+     * @var string
+     */
+    protected $group = 'Trust Levels';
+
+    /**
+     * The Command's Name
+     *
+     * @var string
+     */
+    protected $name = 'trust-levels:visits';
+
+    /**
+     * The Command's Description
+     *
+     * @var string
+     */
+    protected $description = 'Creates a permenant record of a user visiting the site.';
+
+    /**
+     * The Command's Usage
+     *
+     * @var string
+     */
+    protected $usage = 'trust-levels:visits';
+
+    /**
+     * The Command's Arguments
+     *
+     * @var array
+     */
+    protected $arguments = [];
+
+    /**
+     * The Command's Options
+     *
+     * @var array
+     */
+    protected $options = [];
+
+    /**
+     * Actually execute a command.
+     *
+     * @param array $params
+     */
+    public function run(array $params)
+    {
+        $db = db_connect();
+
+        // Create a new entry in the user_visits table for
+        // all users that have a last_active date of today.
+        model(UserModel::class)
+            ->where('last_active', date('Y-m-d'))
+            ->chunk(100, function ($users) use ($db) {
+                foreach ($users as $user) {
+                    try {
+                        $db->table('user_visits')
+                            ->insert([
+                                'user_id' => $user->id,
+                                'visited_on' => date('Y-m-d'),
+                            ]);
+                    } catch (\Exception $e) {
+                        log_message('error', 'Error updating user visits: '. $e->getMessage());
+                    }
+                }
+            });
+
+
+        // Now clean up any old records that are more than 100 days old.
+        $db->table('user_visits')
+            ->where('visited_on <', Time::now()->subDays(100)->toDateString())
+            ->delete();
+    }
+}

--- a/app/Config/Tasks.php
+++ b/app/Config/Tasks.php
@@ -49,6 +49,9 @@ class Tasks extends BaseConfig
         // always set at the last position, so that other tasks can be executed first
         $schedule->command('queue:work emails -max 20 --stop-when-empty')->everyMinute()->named('queue-emails');
 
+        // update the user visits daily
+        $schedule->command('trust-levels:visits')->daily('11:45 pm')->named('track-user-visits');
+
         // update trust levels daily
         $schedule->command('trust-levels:set')->daily('1:00 am')->named('trust-levels-set');
     }

--- a/app/Config/TrustLevels.php
+++ b/app/Config/TrustLevels.php
@@ -58,7 +58,7 @@ class TrustLevels extends BaseConfig
             // 'read-threads' => 30,
         ],
         2 => [
-            // 'daily-visits'   => 15,
+            'daily-visits'   => 15,
             'likes-given'    => 1,
             'likes-received' => 1,
             'replies-given'  => 3,
@@ -66,11 +66,10 @@ class TrustLevels extends BaseConfig
             // 'read-threads'   => 100,
         ],
         3 => [
-            // 'daily-visits'   => 15,
-            'likes-given'    => 1,
-            'likes-received' => 1,
-            'replies-given'  => 3,
-            'new-threads'    => 20,
+            'daily-visits'   => 50,
+            'likes-given'    => 20,
+            'likes-received' => 30,
+            'replies-given'  => 10,
             // 'read-threads'   => 100,
         ],
     ];

--- a/app/Database/Migrations/2024-04-17-042151_CreateUserVisitsTable.php
+++ b/app/Database/Migrations/2024-04-17-042151_CreateUserVisitsTable.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class CreateUserVisitsTable extends Migration
+{
+    public function up()
+    {
+        // Create a table for tracking the days a user visits.
+        $this->forge->addField([
+            'id'         => ['type' => 'int', 'constraint' => 11, 'unsigned' => true, 'auto_increment' => true],
+            'user_id'    => ['type' => 'int', 'constraint' => 11, 'unsigned' => true],
+            'visited_on' => ['type' => 'date'],
+        ]);
+        $this->forge->addPrimaryKey('id');
+        $this->forge->addForeignKey('user_id', 'users', 'id', false, 'CASCADE');
+        $this->forge->createTable('user_visits');
+    }
+
+    public function down()
+    {
+        $this->forge->dropTable('user_visits');
+    }
+}

--- a/app/Libraries/TrustLevels/Assigner.php
+++ b/app/Libraries/TrustLevels/Assigner.php
@@ -100,7 +100,7 @@ class Assigner
             $meetsCriteria = match ($action) {
                 'new-threads' => $user->thread_count >= $value,
                 // 'read-threads' => $user->read_count >= $value,
-                // 'daily-visits' => $user->daily_visits >= $value,
+                'daily-visits' => $user->countDailyVisits() >= $value,
                 'likes-given' => $user->countLikesGiven() >= $value,
                 'likes-received' => $user->countLikesReceived() >= $value,
                 'replies-given' => $user->post_count >= $value,

--- a/tests/Libraries/TrustLevels/AssignerTest.php
+++ b/tests/Libraries/TrustLevels/AssignerTest.php
@@ -2,13 +2,15 @@
 
 namespace Tests\Libraries\TrustLevels;
 
-use App\Entities\User;
 use App\Libraries\TrustLevels\Assigner;
 use App\Models\Factories\UserFactory;
+use Tests\Support\Concerns\SupportsTrustLevels;
 use Tests\Support\TestCase;
 
 class AssignerTest extends TestCase
 {
+    use SupportsTrustLevels;
+
     protected $refresh = true;
 
     public function testAssignNewUser()
@@ -34,6 +36,24 @@ class AssignerTest extends TestCase
         $assigner->assignTrustLevels($user);
 
         $this->assertEquals(1, $user->trust_level);
+    }
+
+    public function testAssignRaiseToLevelTwo()
+    {
+        $assigner = new Assigner();
+        $user = fake(UserFactory::class, [
+            'trust_level' => 0,
+            'thread_count' => 20,
+            'post_count' => 3,
+        ]);
+
+        $this->userLikesPosts($user, 1);
+        $this->userLikedByOthers($user, 1);
+        $this->userVisits($user, 15);
+
+        $assigner->assignTrustLevels($user);
+
+        $this->assertEquals(2, $user->trust_level);
     }
 
     public function testAssignDemotesLevel()

--- a/tests/Libraries/TrustLevels/UserVisitsTest.php
+++ b/tests/Libraries/TrustLevels/UserVisitsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Libraries\TrustLevels;
+
+use App\Commands\UpdateVisits;
+use App\Models\Factories\UserFactory;
+use App\Models\UserModel;
+use Tests\Support\TestCase;
+use CodeIgniter\I18n\Time;
+use Tests\Support\Concerns\SupportsTrustLevels;
+
+class UserVisitsTest extends TestCase
+{
+    use SupportsTrustLevels;
+
+    protected $refresh = true;
+
+    public function testSetTrustLevels()
+    {
+        $user = fake(UserFactory::class, [
+            'active' => true,
+            'trust_level' => 0,
+            'thread_count' => 5,
+            'post_count' => 30,
+            'last_active' => Time::now()->toDateTimeString(),
+        ]);
+        $command = new UpdateVisits(service('logger'), service('commands'));
+
+        $this->userVisits($user, 5);
+
+        $result = $command->run([]);
+
+        $this->assertNull($result);
+
+        // The user should have 5 visits in the database
+        $this->assertEquals(5, $user->countDailyVisits());
+    }
+}

--- a/tests/_support/Concerns/SupportsTrustLevels.php
+++ b/tests/_support/Concerns/SupportsTrustLevels.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Support\Concerns;
+
+use App\Entities\User;
+use App\Models\Factories\PostFactory;
+use App\Models\Factories\ThreadFactory;
+use App\Models\Factories\UserFactory;
+use App\Models\ReactionModel;
+use CodeIgniter\I18n\Time;
+
+trait SupportsTrustLevels
+{
+    /**
+     * Creates a new post and likes it for the user.
+     * Used to test the user giving likes.
+     */
+    protected function userLikesPosts(User $user, int $count)
+    {
+        $reactions = model(ReactionModel::class);
+        $thread = fake(ThreadFactory::class);
+
+        for ($i = 0; $i < $count; $i++) {
+            // Create a new fake post and like it
+            $post = fake(PostFactory::class, ['thread_id' => $thread->id]);
+            $reactions->reactTo($user->id, $post->id, 'post', ReactionModel::REACTION_LIKE);
+        }
+    }
+
+    /**
+     * Creates a new post and has someone else like it.
+     * Used to test the user receiving likes.
+     */
+    protected function userLikedByOthers(User $user, int $count)
+    {
+        $reactions = model(ReactionModel::class);
+        $reactor = fake(UserFactory::class);
+        $thread = fake(ThreadFactory::class);
+
+        for ($i = 0; $i < $count; $i++) {
+            // Create a new fake post and like it
+            $post = fake(PostFactory::class, ['author_id' => $user->id, 'thread_id' => $thread->id]);
+            $reactions->reactTo($reactor->id, $post->id, 'post', ReactionModel::REACTION_LIKE);
+        }
+    }
+
+    /**
+     * Creates a number of visits for the user.
+     */
+    protected function userVisits(User $user, int $count)
+    {
+        $builder = db_connect()->table('user_visits');
+
+        for ($i = 0; $i < $count; $i++) {
+            $builder->insert([
+                'user_id' => $user->id,
+                'visited_on' => Time::now()->subDays($i)->toDateString(),
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
Tracks the number of daily visits for a user over the last 100 days

To avoid doing lots of database calls during the user's visits, a task was scheduled for the last 15 minutes of the day that creates a daily visit log for all users that were active today. 

The task also deletes any entries older than 100 days. 