### PR TITLE
fix: load text_helper

### DIFF
--- a/app/Models/Factories/UserFactory.php
+++ b/app/Models/Factories/UserFactory.php
@@ -30,6 +30,7 @@ class UserFactory extends UserModel
         $username = url_title($username, '-', true);
 
         if ($this->where('username', $username)->first()) {
+            helper('text');
             $username .= '-' . random_string('alnum', 4);
         }
 


### PR DESCRIPTION
the `random_string` function is in the helper text, but this is not loaded at any time, which can generate an error when executing the seed

![image](https://github.com/lonnieezell/forum-example/assets/37987162/f5b60bcc-1ef0-43d9-afb9-1cf97b49f91e)
