### PR TITLE
fix: Track the number of daily visits for a user over the last 100 days. For Trust Levels

### DIFF
--- a/app/Commands/UpdateVisits.php
+++ b/app/Commands/UpdateVisits.php
@@ -65,7 +65,7 @@ class UpdateVisits extends BaseCommand
         // all users that have a last_active date of today.
         model(UserModel::class)
             ->activeToday()
-            ->chunk(100, static function ($users) use ($db) {
+            ->chunk(100, static function ($user) use ($db) {
                 try {
                     $db->table('user_visits')
                         ->insert([

--- a/app/Commands/UpdateVisits.php
+++ b/app/Commands/UpdateVisits.php
@@ -64,18 +64,16 @@ class UpdateVisits extends BaseCommand
         // Create a new entry in the user_visits table for
         // all users that have a last_active date of today.
         model(UserModel::class)
-            ->where('last_active', date('Y-m-d'))
+            ->activeToday()
             ->chunk(100, static function ($users) use ($db) {
-                foreach ($users as $user) {
-                    try {
-                        $db->table('user_visits')
-                            ->insert([
-                                'user_id' => $user->id,
-                                'visited_on' => date('Y-m-d'),
-                            ]);
-                    } catch (Exception $e) {
-                        log_message('error', 'Error updating user visits: '. $e->getMessage());
-                    }
+                try {
+                    $db->table('user_visits')
+                        ->insert([
+                            'user_id' => $user->id,
+                            'visited_on' => date('Y-m-d'),
+                        ]);
+                } catch (Exception $e) {
+                    log_message('error', 'Error updating user visits: '. $e->getMessage());
                 }
             });
 


### PR DESCRIPTION
This PR improves the logic when entering data into `user_visits` table.
```php
<?php

$userModel->chunk(100, static function ($data) {
    // do something.
    // $data is a single row of data.
});
```  
reference: [https://codeigniter.com/user_guide/models/model.html#processing-large-amounts-of-data](https://codeigniter.com/user_guide/models/model.html#processing-large-amounts-of-data)