### PR TITLE
fix: Restore Routes file

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(strict_types=1);


### PR DESCRIPTION
Initially, someone deleted the default **app/Config/Routes.php**. There is a constant error in the log. 

`WARNING - 2024-09-01 19:56:39 --> Routes file not found: "/home/aleksandr/www/codeigniter/forum-example/app/Config/Routes.php"`

This file should be (even empty), the system reads it.