### PR TITLE
fix: Faker deprecations

### DIFF
--- a/app/Models/Factories/ImageFactory.php
+++ b/app/Models/Factories/ImageFactory.php
@@ -20,7 +20,7 @@ class ImageFactory extends ImageModel
             'name'       => $faker->regexify('[0-9]{10}_[a-z0-9]{20}') . '.jpg',
             'size'       => random_int(100000, 2_000_000),
             'is_used'    => 0,
-            'ip_address' => $faker->ipv4,
+            'ip_address' => $faker->ipv4(),
         ]);
     }
 }

--- a/app/Models/Factories/PostFactory.php
+++ b/app/Models/Factories/PostFactory.php
@@ -22,7 +22,7 @@ class PostFactory extends PostModel
             'edited_at'     => null,
             'edited_reason' => null,
             'body'          => $faker->paragraph(5, true),
-            'ip_address'    => $faker->ipv4,
+            'ip_address'    => $faker->ipv4(),
             'include_sig'   => false,
             'visible'       => true,
         ]);

--- a/app/Models/Factories/UserFactory.php
+++ b/app/Models/Factories/UserFactory.php
@@ -14,13 +14,13 @@ class UserFactory extends UserModel
     public function fake(Generator &$faker): User
     {
         return new User([
-            'username' => $this->generateUniqueUsername($faker->userName),
-            'name'     => $faker->name,
-            'email'    => $faker->email,
-            'password' => $faker->password,
+            'username' => $this->generateUniqueUsername($faker->userName()),
+            'name'     => $faker->name(),
+            'email'    => $faker->email(),
+            'password' => $faker->password(),
             'active'   => true,
-            'country'  => $faker->countryCode,
-            'timezone' => $faker->timezone,
+            'country'  => $faker->countryCode(),
+            'timezone' => $faker->timezone(),
             'trust_level' => 0,
         ]);
     }


### PR DESCRIPTION
faker deprecation.

```
WARNING - 2024-09-01 20:18:35 --> [DEPRECATED] Since fakerphp/faker 1.14: Accessing property "ipv4" is deprecated, use "ipv4()" instead. in VENDORPATH/symfony/deprecation-contracts/function.php on line 25.

WARNING - 2024-09-01 20:18:35 --> [DEPRECATED] Since fakerphp/faker 1.14: Accessing property "password" is deprecated, use "password()" instead. in VENDORPATH/symfony/deprecation-contracts/function.php on line 25.

// and others
```