### PR TITLE
fix: Improved work with Post

### DIFF
--- a/app/Entities/Post.php
+++ b/app/Entities/Post.php
@@ -16,7 +16,7 @@ class Post extends Entity
     use HasReactions;
 
     protected $datamap = [];
-    protected $dates   = ['created_at', 'updated_at', 'deleted_at', 'edited_at', 'marked_as_deleted'];
+    protected $dates   = ['created_at', 'updated_at', 'deleted_at', 'edited_at', 'marked_as_deleted', 'marked_as_answer'];
     protected $casts   = [
         'id'          => 'integer',
         'category_id' => 'integer',

--- a/app/Models/PostModel.php
+++ b/app/Models/PostModel.php
@@ -23,7 +23,7 @@ class PostModel extends Model
     protected $useSoftDeletes   = true;
     protected $protectFields    = true;
     protected $allowedFields    = [
-        'category_id', 'thread_id', 'reply_to', 'author_id', 'editor_id', 'edited_at', 'edited_reason', 'body', 'ip_address', 'include_sig', 'visible', 'markup', 'reaction_count',
+        'category_id', 'thread_id', 'reply_to', 'author_id', 'editor_id', 'edited_at', 'edited_reason', 'body', 'ip_address', 'include_sig', 'visible', 'markup', 'reaction_count', 'marked_as_deleted', 'marked_as_answer'
     ];
     protected $useTimestamps        = true;
     protected $cleanValidationRules = false;

--- a/tests/Cells/ActionBarTest.php
+++ b/tests/Cells/ActionBarTest.php
@@ -8,6 +8,7 @@ use App\Models\Factories\CategoryFactory;
 use App\Models\Factories\PostFactory;
 use App\Models\Factories\ThreadFactory;
 use App\Models\Factories\UserFactory;
+use CodeIgniter\I18n\Time;
 use Config\TrustLevels;
 use Tests\Support\TestCase;
 
@@ -188,5 +189,27 @@ final class ActionBarTest extends TestCase
         $post->thread_id = $otherThread->id;
         $this->cell->mount($post, $this->user);
         $this->assertFalse($this->cell->canManageAnswer());
+    }
+
+    public function testUserOwnPostThatIsMarkedAsDeleted(): void
+    {
+        $category = fake(CategoryFactory::class);
+        $myThread = fake(ThreadFactory::class, [
+            'author_id'   => $this->user->id,
+            'category_id' => $category->id,
+        ], true);
+        $post = fake(PostFactory::class, [
+            'author_id'         => fake(UserFactory::class)->id,
+            'thread_id'         => $myThread->id,
+            'category_id'       => $category->id,
+            'marked_as_deleted' => Time::now(),
+            'deleted_at'        => Time::now(),
+        ], true);
+
+        $this->cell->mount($post, $this->user);
+
+        // Cannot be able to edit/delete a deleted post.
+        $this->assertFalse($this->cell->canEdit());
+        $this->assertFalse($this->cell->canDelete());
     }
 }


### PR DESCRIPTION
- [x] Missing attributes have been added for saving via the Model. It was possible to insert only through QueryBuilder.
- [x] Added a test to check for changes to deleted Post.
- [x] 100% coverage `ActionBarCell` 