### PR TITLE
fix: Improved Help section

### DIFF
--- a/app/Controllers/HelpController.php
+++ b/app/Controllers/HelpController.php
@@ -14,23 +14,14 @@ class HelpController extends BaseController
         $markdownPages = service('markdownpages', ROOTPATH . 'help');
 
         if ($this->request->is('post')) {
+            $searchQuery = trim((string) $this->request->getPost('search'));
             $rules = [
-                'search' => ['permit_empty', 'string', 'alpha_numeric_space', 'min_length[4]', 'max_length[32]'],
+                'search' => ['string', 'alpha_numeric_space', 'min_length[4]', 'max_length[32]'],
             ];
 
-            if (! $this->validateData($this->request->getPost(), $rules)) {
+            if (! $this->validateData(['search' => $searchQuery], $rules)) {
                 alerts()->set('error', $this->validator->getError('search'));
 
-                if ($this->request->header('REFERER')?->getValueLine() !== url_to('pages')) {
-                    return '';
-                }
-
-                return $this->render('help/_index', ['pages' => $markdownPages]);
-            }
-
-            $searchQuery = trim((string) $this->request->getPost('search'));
-
-            if ($searchQuery === '') {
                 if ($this->request->header('REFERER')?->getValueLine() !== url_to('pages')) {
                     return '';
                 }

--- a/app/Controllers/HelpController.php
+++ b/app/Controllers/HelpController.php
@@ -14,7 +14,8 @@ class HelpController extends BaseController
         $markdownPages = service('markdownpages', ROOTPATH . 'help');
 
         if ($this->request->is('post')) {
-            $searchQuery = trim((string) $this->request->getPost('search'));
+            $validReferer = $this->request->header('REFERER')?->getValueLine() === url_to('pages');
+            $searchQuery  = trim((string) $this->request->getPost('search'));
             $rules = [
                 'search' => ['string', 'alpha_numeric_space', 'min_length[4]', 'max_length[32]'],
             ];
@@ -22,14 +23,10 @@ class HelpController extends BaseController
             if (! $this->validateData(['search' => $searchQuery], $rules)) {
                 alerts()->set('error', $this->validator->getError('search'));
 
-                if ($this->request->header('REFERER')?->getValueLine() !== url_to('pages')) {
-                    return '';
-                }
-
-                return $this->render('help/_index', ['pages' => $markdownPages]);
+                return $validReferer ? $this->render('help/_index', ['pages' => $markdownPages]) : '';
             }
 
-            return $this->render('help/_search_results', ['search' => $markdownPages->search($searchQuery)]);
+            return $validReferer ? $this->render('help/_search_results', ['search' => $markdownPages->search($searchQuery)]) : '';
         }
 
         return $this->render('help/index', ['pages' => $markdownPages]);

--- a/tests/Controllers/HelpControllerTest.php
+++ b/tests/Controllers/HelpControllerTest.php
@@ -15,7 +15,7 @@ final class HelpControllerTest extends TestCase
         $response = $this->get('help');
 
         $response->assertOK();
-        $response->assertSee('Help Section', 'h1');
+        $response->assertSee('Help', 'h1');
     }
 
     public function testIndexSearch()
@@ -23,6 +23,7 @@ final class HelpControllerTest extends TestCase
         $response = $this
             ->withHeaders([
                 csrf_header() => csrf_hash(),
+                'REFERER'     => url_to('pages'),
             ])
             ->post('help', [
                 'search' => 'sample',
@@ -30,6 +31,22 @@ final class HelpControllerTest extends TestCase
 
         $response->assertOK();
         $response->assertSee('Search Results', 'h3');
+    }
+
+    public function testIndexSearchWithoutReferrer()
+    {
+        $response = $this
+            ->withHeaders([
+                csrf_header() => csrf_hash(),
+                'REFERER'     => '',
+                'HX-Request'  => 'true',
+            ])
+            ->post('help', [
+                'search' => 'sample',
+            ]);
+
+        $this->assertSame(200, $response->response()->getStatusCode());
+        $this->assertEmpty($response->response()->getBody());
     }
 
     public function testIndexSearchEmpty()
@@ -45,6 +62,7 @@ final class HelpControllerTest extends TestCase
             ]);
 
         $response->assertStatus(200);
+        $response->assertSee('The search field may only contain alphanumeric and space characters.', 'span');
     }
 
     public function testIndexSearchValidationError()
@@ -56,7 +74,7 @@ final class HelpControllerTest extends TestCase
                 csrf_header() => csrf_hash(),
             ])
             ->post('help', [
-                'search' => 'sam',
+                'search' => '   sam   ',
             ]);
 
         $response->assertOK();
@@ -68,6 +86,7 @@ final class HelpControllerTest extends TestCase
         $response = $this
             ->withHeaders([
                 csrf_header() => csrf_hash(),
+                'REFERER'     => url_to('pages'),
             ])
             ->post('help', [
                 'search' => 'invalid',

--- a/themes/default/css/app.scss
+++ b/themes/default/css/app.scss
@@ -199,3 +199,14 @@ label.error {
     0%   { transform: translateX(-100%); }
     100% { transform: translateX(100%); }
 }
+
+@media (max-width: 640px) {
+    .container {
+        max-width:640px;
+        padding-inline: 1rem;
+    }
+
+    .navbar > .container {
+        padding-inline: inherit !important;
+    }
+}

--- a/themes/default/help/_header.php
+++ b/themes/default/help/_header.php
@@ -2,17 +2,17 @@
     <div class="hero-content text-center">
         <div class="max-w-max">
             <?php if (empty($page)): ?>
-                <h1 class="text-5xl font-bold">Help Section</h1>
-                <p class="py-6">Provident cupiditate voluptatem et in. Quaerat fugiat ut assumenda excepturi exercitationem quasi.</p>
+                <h1 class="text-5xl font-bold">Help</h1>
+                <p class="py-6">Do you have any questions? We have tried to answer them in this section.</p>
                 <?= form_open('', [
-                    'hx-post' => current_url(),
+                    'hx-post'   => current_url(),
                     'hx-target' => '#help-content-container',
                 ]); ?>
                     <div class="form-control">
-                        <div class="input-group flex-auto">
+                        <div class="input-group flex">
                             <input type="text" name="search" value="<?= set_value('search', $search ?? ''); ?>" maxlength="32"
                                    placeholder="Search..." class="input input-bordered w-full">
-                            <button class="btn btn-square border border-base-300" type="submit" data-loading-disable>
+                            <button class="btn btn-square border border-base-300 mx-1 btn-primary" type="submit" data-loading-disable>
                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
                             </button>
                         </div>

--- a/themes/default/help/_index.php
+++ b/themes/default/help/_index.php
@@ -1,7 +1,9 @@
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 w-full">
+
 <?php foreach ($pages->dirs(null, [1])->items() as $category): ?>
 
     <div class="inline-block" hx-boost="true">
-        <ul class="menu bg-base-200 w-64 rounded-box">
+        <ul class="menu bg-base-200 rounded-box">
             <li class="menu-title"><?= $category->getName(); ?></li>
             <?php foreach ($category->getFiles()->slice(0, 4)->items() as $file): ?>
                 <li><a href="<?= url_to('page', $file->getPath()); ?>"><?= $file->getName(); ?></a></li>
@@ -10,3 +12,5 @@
     </div>
 
 <?php endforeach; ?>
+
+</div>

--- a/themes/default/help/_search_results.php
+++ b/themes/default/help/_search_results.php
@@ -1,15 +1,15 @@
 <?php if ($search->getResults()->isEmpty()): ?>
 
-    <h3>No results, sorry.</h3>
+    <h3 class="font-bold">No results, sorry.</h3>
 
 <?php else: ?>
 
-    <h3>Search Results (<?= $search->getResults()->count(); ?>)</h3>
+    <h3 class="font-bold">Search Results (<?= $search->getResults()->count(); ?>)</h3>
 
     <div hx-boost="true">
         <?php foreach ($search->getResults()->items() as $key => $result): ?>
 
-            <div class="card card-compact bg-base-100 shadow-xl my-6">
+            <div class="card card-compact bg-base-100 shadow-lg my-6">
                 <div class="card-body">
                     <p>
                         <strong><?= ++$key; ?>.</strong>

--- a/themes/default/help/_sidebar.php
+++ b/themes/default/help/_sidebar.php
@@ -1,14 +1,15 @@
-<h2>Help Section</h2>
+<h2>Search in Help Section</h2>
 
 <?= form_open(route_to('pages'), [
-    'hx-post' => route_to('pages'),
+    'hx-post'   => route_to('pages'),
     'hx-target' => '#help-content-container',
+    'class'     => 'mt-2'
 ]); ?>
     <div class="form-control">
-        <div class="input-group flex-auto">
+        <div class="input-group flex">
             <input type="text" name="search" value="<?= set_value('search', $search ?? ''); ?>" maxlength="32"
                    placeholder="Search..." class="input input-bordered w-full">
-            <button class="btn btn-square border border-base-300" type="submit" data-loading-disable>
+            <button class="btn btn-square border border-base-300 mx-1 btn-primary" type="submit" data-loading-disable>
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
             </button>
         </div>


### PR DESCRIPTION
- [x] Rework the `HelpController`  to work with an empty query.
- [x] I didn't quite understand the involvement of the Referer for the response. It is almost always needed in other places, not just in search. I left this feature. 
- [x] Blocks with **.container** are now indented on the small screen. 
- [x] 100% coverage with `HelpController` tests.
- [x]  Improved design
Video example: https://disk.yandex.ru/d/8OW6-sASKaxCig
