### PR TITLE
fix: Revert response for search in Help

### DIFF
--- a/app/Controllers/HelpController.php
+++ b/app/Controllers/HelpController.php
@@ -14,8 +14,7 @@ class HelpController extends BaseController
         $markdownPages = service('markdownpages', ROOTPATH . 'help');
 
         if ($this->request->is('post')) {
-            $validReferer = $this->request->header('REFERER')?->getValueLine() === url_to('pages');
-            $searchQuery  = trim((string) $this->request->getPost('search'));
+            $searchQuery   = trim((string) $this->request->getPost('search'));
             $rules = [
                 'search' => ['string', 'alpha_numeric_space', 'min_length[4]', 'max_length[32]'],
             ];
@@ -23,10 +22,12 @@ class HelpController extends BaseController
             if (! $this->validateData(['search' => $searchQuery], $rules)) {
                 alerts()->set('error', $this->validator->getError('search'));
 
-                return $validReferer ? $this->render('help/_index', ['pages' => $markdownPages]) : '';
+                return $this->request->header('REFERER')?->getValueLine() === url_to('pages')
+                    ? $this->render('help/_index', ['pages' => $markdownPages])
+                    : '';
             }
 
-            return $validReferer ? $this->render('help/_search_results', ['search' => $markdownPages->search($searchQuery)]) : '';
+            return $this->render('help/_search_results', ['search' => $markdownPages->search($searchQuery)]);
         }
 
         return $this->render('help/index', ['pages' => $markdownPages]);

--- a/tests/Controllers/HelpControllerTest.php
+++ b/tests/Controllers/HelpControllerTest.php
@@ -46,7 +46,7 @@ final class HelpControllerTest extends TestCase
             ]);
 
         $this->assertSame(200, $response->response()->getStatusCode());
-        $this->assertEmpty($response->response()->getBody());
+        $response->assertSee('Sample File', 'a');
     }
 
     public function testIndexSearchEmpty()


### PR DESCRIPTION
I didn't understand the behavior for the search a bit. 

he response from the Help page should contain a list of pages, and if the search is performed from the sidebar, an empty response should be returned.